### PR TITLE
Fix runewidth

### DIFF
--- a/box.go
+++ b/box.go
@@ -1,12 +1,5 @@
 package termui
 
-const TOP_RIGHT = '┐'
-const VERTICAL_LINE = '│'
-const HORIZONTAL_LINE = '─'
-const TOP_LEFT = '┌'
-const BOTTOM_RIGHT = '┘'
-const BOTTOM_LEFT = '└'
-
 type border struct {
 	X       int
 	Y       int

--- a/box_others.go
+++ b/box_others.go
@@ -1,0 +1,10 @@
+// +build !windows
+
+package termui
+
+const TOP_RIGHT = '┐'
+const VERTICAL_LINE = '│'
+const HORIZONTAL_LINE = '─'
+const TOP_LEFT = '┌'
+const BOTTOM_RIGHT = '┘'
+const BOTTOM_LEFT = '└'

--- a/box_windows.go
+++ b/box_windows.go
@@ -1,0 +1,10 @@
+// +build windows
+
+package termui
+
+const TOP_RIGHT = '+'
+const VERTICAL_LINE = '|'
+const HORIZONTAL_LINE = '-'
+const TOP_LEFT = '+'
+const BOTTOM_RIGHT = '+'
+const BOTTOM_LEFT = '+'

--- a/chart.go
+++ b/chart.go
@@ -2,10 +2,6 @@ package termui
 
 import "fmt"
 
-const VDASH = '┊'
-const HDASH = '┈'
-const ORIGIN = '└'
-
 // only 16 possible combinations, why bother
 var braillePatterns = map[[2]int]rune{
 	[2]int{0, 0}: '⣀',

--- a/chart_others.go
+++ b/chart_others.go
@@ -1,0 +1,7 @@
+// +build !windows
+
+package termui
+
+const VDASH = '┊'
+const HDASH = '┈'
+const ORIGIN = '└'

--- a/chart_windows.go
+++ b/chart_windows.go
@@ -1,0 +1,7 @@
+// +build windows
+
+package termui
+
+const VDASH = '|'
+const HDASH = '-'
+const ORIGIN = '+'

--- a/helper.go
+++ b/helper.go
@@ -25,6 +25,11 @@ const (
 	AttrReverse
 )
 
+var (
+	dot  = "…"
+	dotw = rw.StringWidth(dot)
+)
+
 /* ----------------------- End ----------------------------- */
 
 func toTmAttr(x Attribute) tm.Attribute {
@@ -39,5 +44,10 @@ func trimStr2Runes(s string, w int) []rune {
 	if w <= 0 {
 		return []rune{}
 	}
-	return []rune(rw.Truncate(s, w, "…"))
+	sw := rw.StringWidth(s)
+	if sw+dotw >= w {
+		return []rune(rw.Truncate(s, w, ""))
+	} else {
+		return []rune(rw.Truncate(s, w, "…"))
+	}
 }

--- a/helper.go
+++ b/helper.go
@@ -1,8 +1,7 @@
 package termui
 
-import "unicode/utf8"
-import "strings"
 import tm "github.com/nsf/termbox-go"
+import rw "github.com/mattn/go-runewidth"
 
 /* ---------------Port from termbox-go --------------------- */
 
@@ -33,25 +32,12 @@ func toTmAttr(x Attribute) tm.Attribute {
 }
 
 func str2runes(s string) []rune {
-	n := utf8.RuneCountInString(s)
-	ss := strings.Split(s, "")
-
-	rs := make([]rune, n)
-	for i := 0; i < n; i++ {
-		r, _ := utf8.DecodeRuneInString(ss[i])
-		rs[i] = r
-	}
-	return rs
+	return []rune(s)
 }
 
 func trimStr2Runes(s string, w int) []rune {
-	rs := str2runes(s)
 	if w <= 0 {
 		return []rune{}
 	}
-	if len(rs) > w {
-		rs = rs[:w]
-		rs[w-1] = '…'
-	}
-	return rs
+	return []rune(rw.Truncate(s, w, "…"))
 }


### PR DESCRIPTION
On windows, multi-byte characters are displayed as two-cells. For example border of box is displayed as two-cells. So it should use ASCII characters.
![](http://go-gyazo.appspot.com/73329c96e069da7c.png)