### PR TITLE
Added new public (exported) getter for Theme. Fixes #6

### DIFF
--- a/theme.go
+++ b/theme.go
@@ -1,6 +1,7 @@
 package termui
 
-type colorScheme struct {
+// A ColorScheme represents the current look-and-feel of the dashboard.
+type ColorScheme struct {
 	BodyBg            Attribute
 	BlockBg           Attribute
 	HasBorder         bool
@@ -24,9 +25,9 @@ type colorScheme struct {
 }
 
 // default color scheme depends on the user's terminal setting.
-var themeDefault = colorScheme{HasBorder: true}
+var themeDefault = ColorScheme{HasBorder: true}
 
-var themeHelloWorld = colorScheme{
+var themeHelloWorld = ColorScheme{
 	BodyBg:            ColorBlack,
 	BlockBg:           ColorBlack,
 	HasBorder:         true,
@@ -51,6 +52,18 @@ var themeHelloWorld = colorScheme{
 
 var theme = themeDefault // global dep
 
+// Theme returns the currently used theme.
+func Theme() ColorScheme {
+	return theme
+}
+
+// SetTheme sets a new, custom theme.
+func SetTheme(newTheme ColorScheme) {
+	theme = newTheme
+}
+
+// UseTheme sets a predefined scheme. Currently available: "hello-world" and
+// "black-and-white".
 func UseTheme(th string) {
 	switch th {
 	case "helloworld":


### PR DESCRIPTION
I didn't make Theme a variable because that might break existing code and I didn't name the getter `GetTheme()` because of the [design guidelines](https://golang.org/doc/effective_go.html#Getters):

> it's neither idiomatic nor necessary to put Get into the getter's name.


I made `ColorScheme` public so that the design ist customizable. I also added a setter for theme which should be used for a customized design. Using `UseTheme` is still fine if the builtin look-and-feels are good enough. 