### PR TITLE
Travis badge improvement and godoc reference badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# termui ![build status](https://travis-ci.org/gizak/termui.svg?branch=master)
+# termui [![Build Status](https://travis-ci.org/gizak/termui.svg)](https://travis-ci.org/gizak/termui) ![Doc Status](https://godoc.org/github.com/gizak/termui?status.png)
+
+---
+
 Go terminal dashboard. Inspired by [blessed-contrib](https://github.com/yaronn/blessed-contrib), but purely in Go.
 
 Cross-platform, easy to compile, and fully-customizable.


### PR DESCRIPTION
Added the badge godoc reference and fixed the link to the travis page.  You were previously redirected to the raw image when clicking on the travis icon instead of the build page (as you would expect).