### PR TITLE
Fix an OutofIndex Panic on empty bargraphs and introduce SetMax()

### DIFF
--- a/bar.go
+++ b/bar.go
@@ -59,13 +59,24 @@ func (bc *BarChart) layout() {
 		bc.dataNum[i] = trimStr2Runes(s, bc.BarWidth)
 	}
 
-	bc.max = bc.Data[0] //  what if Data is nil?
+	//bc.max = bc.Data[0] //  what if Data is nil? Sometimes when bar graph is nill it produces panic with panic: runtime error: index out of range
+	// Asign a negative value to get maxvalue auto-populates
+	if bc.max == 0 {
+		bc.max = -1
+	}
 	for i := 0; i < len(bc.Data); i++ {
 		if bc.max < bc.Data[i] {
 			bc.max = bc.Data[i]
 		}
 	}
 	bc.scale = float64(bc.max) / float64(bc.innerHeight-1)
+}
+
+func (bc *BarChart) SetMax(max int) {
+
+	if max > 0 {
+		bc.max = max
+	}
 }
 
 // Buffer implements Bufferer interface.


### PR DESCRIPTION
Hi,

First of all thanks for this awesome package. :-)

When the barGraph's Data[] is null it produces panic like below. 

```
panic: runtime error: index out of range

goroutine 1 [running]:
github.com/gizak/termui.(*BarChart).layout(0xc208050280)
        /home/cf/gopkg/src/github.com/gizak/termui/bar.go:62 +0x577
github.com/gizak/termui.(*BarChart).Buffer(0xc208050280, 0x0, 0x0, 0x0)
        /home/cf/gopkg/src/github.com/gizak/termui/bar.go:74 +0xb5
github.com/gizak/termui.Render(0xc20811d720, 0x4, 0x4)
        /home/cf/gopkg/src/github.com/gizak/termui/render.go:52 +0xc7
github.com/cloudfoundry-incubator/lattice/ltc/app_examiner/command_factory.(*AppExaminerCommandFactory).printDistributionChart(0xc20802d3c0, 0x3b9aca00, 0x0, 0x0)
        /home/cf/gopkg/src/github.com/cloudfoundry-incubator/lattice/ltc/Godeps/_workspace/src/github.com/cloudfoundry-incubator/lattice/ltc/app_examiner/command_factory/app_examiner_command_factory.go:483 +0xfd5
``` 

Plus sometime when i want my bar graph to always have maxValue as 100 (while calculating percentage) it does not work.  The maximum among data[] is always considered, so my graph becomes less realistic. 

This allows us have more realistic graph and also we are able to plot empty barGraphs. 