### PR TITLE
Fixes unsafe pointer madness.

### DIFF
--- a/events.go
+++ b/events.go
@@ -9,7 +9,6 @@
 package termui
 
 import "github.com/nsf/termbox-go"
-import "unsafe"
 
 /***********************************termbox-go**************************************/
 
@@ -133,7 +132,19 @@ const (
 
 // convert termbox.Event to termui.Event
 func uiEvt(e termbox.Event) Event {
-	return *(*Event)(unsafe.Pointer(&e))
+	event := Event{}
+	event.Type = EventType(e.Type)
+	event.Mod = Modifier(e.Mod)
+	event.Key = Key(e.Key)
+	event.Ch = e.Ch
+	event.Width = e.Width
+	event.Height = e.Height
+	event.Err = e.Err
+	event.MouseX = e.MouseX
+	event.MouseY = e.MouseY
+	event.N = e.N
+
+	return event
 }
 
 var evtChs = make([]chan Event, 0)

--- a/events_test.go
+++ b/events_test.go
@@ -1,0 +1,28 @@
+// Copyright 2015 Zack Guo <gizak@icloud.com>. All rights reserved.
+// Use of this source code is governed by a MIT license that can
+// be found in the LICENSE file.
+//
+// Portions of this file uses [termbox-go](https://github.com/nsf/termbox-go/blob/54b74d087b7c397c402d0e3b66d2ccb6eaf5c2b4/api_common.go)
+// by [authors](https://github.com/nsf/termbox-go/blob/master/AUTHORS)
+// under [license](https://github.com/nsf/termbox-go/blob/master/LICENSE)
+
+package termui
+
+import (
+	"errors"
+	"testing"
+
+	termbox "github.com/nsf/termbox-go"
+	"github.com/stretchr/testify/assert"
+)
+
+type boxEvent termbox.Event
+
+func TestUiEvt(t *testing.T) {
+	err := errors.New("This is a mock error")
+	event := boxEvent{3, 5, 2, 'H', 200, 500, err, 50, 30, 2}
+	expetced := Event{3, 5, 2, 'H', 200, 500, err, 50, 30, 2}
+
+	// We need to do that ugly casting so that vet does not complain
+	assert.Equal(t, uiEvt(termbox.Event(event)), expetced)
+}


### PR DESCRIPTION
While doing a code-review of changeset 7be8d02, which introduced #27, I
realized that you used the `unsafe` package and introduced a bufferflow
bug, if `termbox.Event` changes.

`func uiEvt(e termbox.Event) Event` used to change the type of termbox.Event to Event by
using some pointer-cast magic[1], which could cause an overflow if `termbox.Event` changes
its structure.
I'd rather just have `type Event termbox.Event` but that would break backwards compatibility.

Warning: A buffer overflow could cause a serious security issue but it is very unlikely that
anyone could exploit that (though not impossbible). You'd need to push a upstream update to
termbox, which would tweak termbox.Event's structure. Still, this issue should be fixed and
unsafe should never be used.

[1] it used to get the address of termbox.Event and just cast a Event pointer