### PR TITLE
Fixed a bug which would render the background color of a label incorrectly.

### DIFF
--- a/gauge.go
+++ b/gauge.go
@@ -97,7 +97,7 @@ func (g *Gauge) Buffer() []Point {
 		p.Y = pry
 		p.Ch = v
 		p.Fg = g.PercentColor
-		if w > pos+i {
+		if w+g.innerX > pos+i {
 			p.Bg = g.BarColor
 			if p.Bg == ColorDefault {
 				p.Bg |= AttrReverse


### PR DESCRIPTION
Fixed a bug which would render the background color of the label in the gauge widget incorrectly.  
This bug was introduced in changeset 137d2a7.

Before:
![screen shot 2015-04-23 at 12 27 29 pm](https://cloud.githubusercontent.com/assets/1218474/7295240/20462f54-e9b4-11e4-986b-7e0e24ccbabe.png)

After:
![screen shot 2015-04-23 at 12 28 00 pm](https://cloud.githubusercontent.com/assets/1218474/7295241/2047cd28-e9b4-11e4-82da-6ef6faa24922.png)
