### PR TITLE
Fill background for borderless one-line paragraph

### DIFF
--- a/block.go
+++ b/block.go
@@ -92,8 +92,12 @@ func (d *Block) Buffer() []Point {
 	for i := 0; i < d.innerWidth; i++ {
 		for j := 0; j < d.innerHeight; j++ {
 			p := Point{}
-			p.X = d.X + 1 + i
-			p.Y = d.Y + 1 + j
+			p.X = d.X + i
+			p.Y = d.Y + j
+			if d.HasBorder {
+				p.X++
+				p.Y++
+			}
 			p.Ch = ' '
 			p.Bg = d.BgColor
 			ps = append(ps, p)

--- a/p_test.go
+++ b/p_test.go
@@ -1,0 +1,20 @@
+package termui
+
+import "testing"
+
+func TestPar_NoBorderBackground(t *testing.T) {
+	par := NewPar("a")
+	par.HasBorder = false
+	par.BgColor = ColorBlue
+	par.TextBgColor = ColorBlue
+	par.Width = 2
+	par.Height = 2
+
+	pts := par.Buffer()
+	for _, p := range pts {
+		t.Log(p)
+		if p.Bg != par.BgColor {
+			t.Errorf("expected color to be %v but got %v", par.BgColor, p.Bg)
+		}
+	}
+}


### PR DESCRIPTION
Previously when we had a Par with Width > len(Text) and custom BgColor on the underlying Block, it would skip the first row and column.
The colored Points were there but offset by one and chopped off by Par.
This means that it's impossible to have a colored line wider than text width.
Block should offset indexes by 1 only if border is present.