### PR TITLE
Feature textwrapping

### DIFF
--- a/_example/wrappar.go
+++ b/_example/wrappar.go
@@ -1,0 +1,32 @@
+package main
+
+import ui "github.com/jrmiller82/termui"
+
+func main() {
+
+	err := ui.Init()
+	if err != nil {
+		panic(err)
+	}
+	defer ui.Close()
+
+	p := ui.NewPar("Press q to QUIT THE DEMO. [There](fg-blue) are other things [that](fg-red) are going to fit in here I think. What do you think? Now is the time for all good [men to](bg-blue) come to the aid of their country. [This is going to be one really really really long line](fg-green) that is going to go together and stuffs and things. Let's see how this thing renders out.\n    Here is a new paragraph and stuffs and things. There should be a tab indent at the beginning of the paragraph. Let's see if that worked as well.")
+	p.WrapLength = 48 // this should be at least p.Width - 2
+	p.Height = 30
+	p.Width = 50
+	p.Y = 2
+	p.X = 20
+	p.TextFgColor = ui.ColorWhite
+	p.BorderLabel = "Text Box with Wrapping"
+	p.BorderFg = ui.ColorCyan
+	//p.Border = false
+
+	ui.Render(p)
+
+	ui.Handle("/sys/kbd/q", func(ui.Event) {
+		ui.StopLoop()
+	})
+
+	ui.Loop()
+
+}

--- a/par.go
+++ b/par.go
@@ -16,6 +16,7 @@ type Par struct {
 	Text        string
 	TextFgColor Attribute
 	TextBgColor Attribute
+	WrapLength  uint
 }
 
 // NewPar returns a new *Par with given text as its content.
@@ -25,6 +26,7 @@ func NewPar(s string) *Par {
 		Text:        s,
 		TextFgColor: ThemeAttr("par.text.fg"),
 		TextBgColor: ThemeAttr("par.text.bg"),
+		WrapLength:  0,
 	}
 }
 
@@ -33,7 +35,12 @@ func (p *Par) Buffer() Buffer {
 	buf := p.Block.Buffer()
 
 	fg, bg := p.TextFgColor, p.TextBgColor
-	cs := DefaultTxBuilder.Build(p.Text, fg, bg)
+	cs := []Cell{}
+	if p.WrapLength < 1 {
+		cs = DefaultTxBuilder.Build(p.Text, fg, bg)
+	} else {
+		cs = DefaultTxBuilder.BuildWrap(p.Text, fg, bg, p.WrapLength)
+	}
 
 	y, x, n := 0, 0, 0
 	for y < p.innerArea.Dy() && n < len(cs) {

--- a/textbuilder.go
+++ b/textbuilder.go
@@ -217,16 +217,15 @@ func (mtb MarkdownTxBuilder) BuildWrap(s string, fg, bg Attribute, wl uint) []Ce
 			} else if plainRune[i] != plainWrappedRune[i] && plainWrappedRune[i] == 10 {
 				trigger = "go"
 				cell := Cell{10, 0, 0}
+				j := i - 0
 
 				// insert a cell into the []Cell in correct position
-				tmpCell = append(tmpCell, Cell{0, 0, 0})
-				copy(tmpCell[i+1:], tmpCell[i:])
 				tmpCell[i] = cell
 
 				// insert the newline into plain so we avoid indexing errors
 				plainRuneNew = append(plainRune, 10)
-				copy(plainRuneNew[i+1:], plainRuneNew[i:])
-				plainRuneNew[i] = plainWrappedRune[i]
+				copy(plainRuneNew[j+1:], plainRuneNew[j:])
+				plainRuneNew[j] = plainWrappedRune[j]
 
 				// restart the inner for loop until plain and plain wrapped are
 				// the same; yeah, it's inefficient, but the text amounts

--- a/textbuilder.go
+++ b/textbuilder.go
@@ -1,7 +1,6 @@
 package termui
 
 import (
-	"fmt"                              // for debugging; REMOVE ME BEFORE PULL REQUEST
 	"github.com/mitchellh/go-wordwrap" // LEFT UP TO PKG MAINTAINER TO DECIDE HOW TO VENDOR; is MIT LICENSED
 	"regexp"
 	"strings"
@@ -185,7 +184,6 @@ func (mtb *MarkdownTxBuilder) parse(str string) {
 	}
 
 	mtb.plainTx = normTx
-	fmt.Printf("DEBUG: printing mtb.plainTx during parse func: %+v\n", string(mtb.plainTx)) // TODO delete me
 }
 
 // BuildWrap implements TextBuilder interface and will naively wrap the plain
@@ -199,11 +197,9 @@ func (mtb MarkdownTxBuilder) BuildWrap(s string, fg, bg Attribute, wl uint) []Ce
 	// get the plaintext
 	mtb.parse(s)
 	plain := string(mtb.plainTx)
-	fmt.Printf("DEBUG: %v\n", plain) // TODO delete me when working
 
 	// wrap
 	plainWrapped := wordwrap.WrapString(plain, wl)
-	fmt.Printf("DEBUG: wrapped plain string\n %s\n", plainWrapped) // TODO delete me when working
 
 	// find differences and insert
 	finalCell := tmpCell // finalcell will get the inserts and is what is returned
@@ -217,7 +213,6 @@ func (mtb MarkdownTxBuilder) BuildWrap(s string, fg, bg Attribute, wl uint) []Ce
 		plainRune = plainRuneNew
 		for i, _ := range plainRune {
 			if plainRune[i] == plainWrappedRune[i] {
-				fmt.Println("DEBUG: compy ", plainRune[i], plainWrappedRune[i]) // TODO delete me when working
 				trigger = "stop"
 			} else if plainRune[i] != plainWrappedRune[i] && plainWrappedRune[i] == 10 {
 				trigger = "go"
@@ -236,9 +231,7 @@ func (mtb MarkdownTxBuilder) BuildWrap(s string, fg, bg Attribute, wl uint) []Ce
 				// restart the inner for loop until plain and plain wrapped are
 				// the same; yeah, it's inefficient, but the text amounts
 				// should be small
-				fmt.Println("Inserted a new line character")
 				break
-				fmt.Println("Breaking")
 
 			} else if plainRune[i] != plainWrappedRune[i] &&
 				plainWrappedRune[i-1] == 10 && // if the prior rune is a newline
@@ -247,13 +240,10 @@ func (mtb MarkdownTxBuilder) BuildWrap(s string, fg, bg Attribute, wl uint) []Ce
 				// need to delete plainRune[i] because it gets rid of an extra
 				// space
 				plainRuneNew = append(plainRune[:i], plainRune[i+1:]...)
-				fmt.Println("Deleting extra space")
 				break
-				fmt.Println("Breaking")
 
 			} else {
 				trigger = "stop" // stops the outer for loop
-				fmt.Println("Stopping: ", plainRune[i], plainWrappedRune[i])
 			}
 		}
 	}

--- a/textbuilder.go
+++ b/textbuilder.go
@@ -2,14 +2,15 @@ package termui
 
 import (
 	"fmt"                              // for debugging; REMOVE ME BEFORE PULL REQUEST
-	"github.com/mitchellh/go-wordwrap" // LEFT UP TO PKG MAINTAINER TO DECIDE HOW TO VENDOR
+	"github.com/mitchellh/go-wordwrap" // LEFT UP TO PKG MAINTAINER TO DECIDE HOW TO VENDOR; is MIT LICENSED
 	"regexp"
 	"strings"
 )
 
-// TextBuilder is a minial interface to produce text []Cell using sepcific syntax (markdown).
+// TextBuilder is a minimal interface to produce text []Cell using specific syntax (markdown).
 type TextBuilder interface {
 	Build(s string, fg, bg Attribute) []Cell
+	BuildWrap(s string, fg, bg Attribute, wl uint) []Cell
 }
 
 // DefaultTxBuilder is set to be MarkdownTxBuilder.


### PR DESCRIPTION
Gizak:

Here's a quick and dirty addition of text wrapping to anything called with NewPar. If the Par has a Par.WrapLength greater than x, a new varation of Build called BuildWrap is called. It still retains your neat markdown color syntax while getting nice naive wrapping of the text. 

It's less efficient than it could be; I'm self taught so my logic might not be the best. I used a loop that breaks and re-reruns a lot to make sure the unwrapped and wrapped texts were properly compared and to avoid index errors. There is likely a more efficient way to do this; but, since we're just talking about wrapping small amounts of text, and with Go's inherent speed, I'm not too worried about it. 

It imports (but does not vendor) github.com/mitchellh/go-wordwrap (MIT licensed). The import is called in textbuilder.go. The src is fairly short if you want to bring it inside of termui so you're not having to import it. But, I'll leave that decision up to you. 

I also added the BuildWrap func to the TextBuilder interface as it was the only way to get around not having to entirely rewrite the whole call stack. Maybe in the future it would be best to just rewrite Build to take into account the wrapping logic in BuildWrap; but, I couldn't exactly grok your build stuff... 

Let me know what you think. Termui rocks! 

Oh, after the PR, the import statement in the example file points to my fork, and not the main repo; it will need to be changed. 

