### PR TITLE
Add missing 'yellow' to TextBuilder

### DIFF
--- a/textbuilder.go
+++ b/textbuilder.go
@@ -33,6 +33,7 @@ var colorMap = map[string]Attribute{
 	"blue":    ColorBlue,
 	"black":   ColorBlack,
 	"cyan":    ColorCyan,
+	"yellow":  ColorYellow,
 	"white":   ColorWhite,
 	"default": ColorDefault,
 	"green":   ColorGreen,


### PR DESCRIPTION
'yellow' wasn't included in the colorMap used by TextBuilder, making it impossible to specify that very handy color from within text.