### PR TITLE
Use "ui" instead of "termui" in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,22 +93,22 @@ Grid layout uses [12 columns grid system](http://www.w3schools.com/bootstrap/boo
 
 ```go
 	// handle key q pressing
-	termui.Handle("/sys/kbd/q", func(termui.Event) {
+	ui.Handle("/sys/kbd/q", func(ui.Event) {
 		// press q to quit
-		termui.StopLoop()
+		ui.StopLoop()
 	})
 
-	termui.Handle("/sys/kbd/C-x", func(termui.Event) {
+	ui.Handle("/sys/kbd/C-x", func(ui.Event) {
 		// handle Ctrl + x combination
 	})
 
-	termui.Handle("/sys/kbd", func(termui.Event) {
+	ui.Handle("/sys/kbd", func(ui.Event) {
 		// handle all other key pressing
 	})
 
 	// handle a 1s timer
-	termui.Handle("/timer/1s", func(e ui.Event) {
-		t := e.Data.(termui.EvtTimer)
+	ui.Handle("/timer/1s", func(e ui.Event) {
+		t := e.Data.(ui.EvtTimer)
 		// t is a EvtTimer
 		if t.Count%2 ==0 {
 			// do something


### PR DESCRIPTION
To be consistent with the other examples.