### PR TITLE
Allow to plot datapoints with both coordinates defined. Closes #68

### DIFF
--- a/linechart.go
+++ b/linechart.go
@@ -46,6 +46,12 @@ var rSingleBraille = [4]rune{'\u2880', '⠠', '⠐', '⠈'}
   lc.AxesColor = termui.ColorWhite
   lc.LineColor = termui.ColorGreen | termui.AttrBold
   // termui.Render(lc)...
+
+  If you want to use XS chart, you need to add
+  lc.IsXS = true
+  lc.XS = [2, 3, 6, 8, 10, 12, 16, 20]
+  Note that numbers should be non-negative integers.
+  Setting XS not in increasing order may lead to unexpected results.
 */
 type LineChart struct {
 	Block
@@ -362,16 +368,19 @@ func (lc *LineChart) recalData() {
 	prevX := 0
 	nextX := 1
 
-	for x := xMin; x < xMax; x++ {
+	for x := 0; x < size; x++ {
 		if x == lc.XS[prevX] {
 			lc.data[x] = lc.Data[prevX]
-			lc.xs[x] = x
+
+			lc.xs[x] = x + xMin
 			continue
 		}
 
 		if x == lc.XS[nextX] {
 			lc.data[x] = lc.Data[nextX]
-			lc.xs[x] = x
+
+			lc.xs[x] = x + xMin
+
 			prevX += 1
 			nextX += 1
 			continue
@@ -380,7 +389,7 @@ func (lc *LineChart) recalData() {
 		k := (lc.Data[nextX] - lc.Data[prevX]) / float64((lc.XS[nextX] - lc.XS[prevX]))
 		lc.data[x] = lc.Data[prevX] + k*float64(x-lc.XS[prevX])
 
-		lc.xs[x] = x
+		lc.xs[x] = x + xMin
 	}
 }
 

--- a/linechart.go
+++ b/linechart.go
@@ -358,7 +358,7 @@ func (lc *LineChart) recalData() {
 	xMin := lc.XS[0]
 	xMax := lc.XS[len(lc.XS)-1]
 
-	size := xMax - xMin
+	size := xMax - xMin + 1
 
 	if len(lc.data) != size {
 		lc.data = make([]float64, size)

--- a/linechart.go
+++ b/linechart.go
@@ -50,6 +50,8 @@ var rSingleBraille = [4]rune{'\u2880', '⠠', '⠐', '⠈'}
 type LineChart struct {
 	Block
 	Data          []float64
+	IsXS          bool
+	XS            []int
 	DataLabels    []string // if unset, the data indices will be used
 	Mode          string   // braille | dot
 	DotStyle      rune
@@ -78,6 +80,7 @@ func NewLineChart() *LineChart {
 	lc.LineColor = ThemeAttr("linechart.line.fg")
 	lc.Mode = "braille"
 	lc.DotStyle = '•'
+	lc.IsXS = false
 	lc.axisXLebelGap = 2
 	lc.axisYLebelGap = 1
 	lc.bottomValue = math.Inf(1)
@@ -110,20 +113,39 @@ func (lc *LineChart) renderBraille() Buffer {
 				Fg: lc.LineColor,
 			}
 			y := lc.innerArea.Min.Y + lc.innerArea.Dy() - 3 - b0
-			x := lc.innerArea.Min.X + lc.labelYSpace + 1 + i
+			x := lc.innerArea.Min.X + lc.labelYSpace + 1
+
+			if lc.IsXS {
+				x += lc.XS[i]
+			} else {
+				x += i
+			}
 			buf.Set(x, y, c)
 		} else {
 			c0 := Cell{Ch: lSingleBraille[m0],
 				Fg: lc.LineColor,
 				Bg: lc.Bg}
-			x0 := lc.innerArea.Min.X + lc.labelYSpace + 1 + i
+			x0 := lc.innerArea.Min.X + lc.labelYSpace + 1
+			if lc.IsXS {
+				x0 += lc.XS[i]
+			} else {
+				x0 += i
+			}
+
 			y0 := lc.innerArea.Min.Y + lc.innerArea.Dy() - 3 - b0
 			buf.Set(x0, y0, c0)
 
 			c1 := Cell{Ch: rSingleBraille[m1],
 				Fg: lc.LineColor,
 				Bg: lc.Bg}
-			x1 := lc.innerArea.Min.X + lc.labelYSpace + 1 + i
+			x1 := lc.innerArea.Min.X + lc.labelYSpace + 1
+
+			if lc.IsXS {
+				x1 += lc.XS[i]
+			} else {
+				x1 += i
+			}
+
 			y1 := lc.innerArea.Min.Y + lc.innerArea.Dy() - 3 - b1
 			buf.Set(x1, y1, c1)
 		}
@@ -140,7 +162,15 @@ func (lc *LineChart) renderDot() Buffer {
 			Fg: lc.LineColor,
 			Bg: lc.Bg,
 		}
-		x := lc.innerArea.Min.X + lc.labelYSpace + 1 + i
+
+		x := lc.innerArea.Min.X + lc.labelYSpace + 1
+
+		if lc.IsXS {
+			x += lc.XS[i]
+		} else {
+			x += i
+		}
+
 		y := lc.innerArea.Min.Y + lc.innerArea.Dy() - 3 - int((lc.Data[i]-lc.bottomValue)/lc.scale+0.5)
 		buf.Set(x, y, c)
 	}


### PR DESCRIPTION
Allows users to define both x and y coordinates for linechart.
E.g. this will plot line with three "main" points at (4, 1), (6,4) and (10,2) with linear interpolation in between.

``` go
lc.Data = [1, 4, 2]
lc.IsXS = true
lc.XS = [4, 6, 10]
```

This closes #68.
