### PR TITLE
Clear screen during re-layouts in example

### DIFF
--- a/_example/grid.go
+++ b/_example/grid.go
@@ -114,6 +114,7 @@ func main() {
 	ui.Handle("/sys/wnd/resize", func(e ui.Event) {
 		ui.Body.Width = ui.TermWidth()
 		ui.Body.Align()
+		ui.Clear()
 		ui.Render(ui.Body)
 	})
 


### PR DESCRIPTION
Doing re-layout for changes in window size may leave coordinates that are now not painted over by any active components.  (I experienced this when updating the example to have the `ls` object take up 2 grid widths and be offset 1, for example.)  It's probably a good idea to pair big re-layout&re-draw operations with a `Clear` call.