### PR TITLE
Make BarChart cell character configurable.

### DIFF
--- a/barchart.go
+++ b/barchart.go
@@ -29,6 +29,7 @@ type BarChart struct {
 	DataLabels []string
 	BarWidth   int
 	BarGap     int
+	CellChar   rune
 	labels     [][]rune
 	dataNum    [][]rune
 	numBar     int
@@ -44,6 +45,7 @@ func NewBarChart() *BarChart {
 	bc.TextColor = ThemeAttr("barchart.text.fg")
 	bc.BarGap = 1
 	bc.BarWidth = 3
+	bc.CellChar = ' '
 	return bc
 }
 
@@ -91,7 +93,7 @@ func (bc *BarChart) Buffer() Buffer {
 		for j := 0; j < bc.BarWidth; j++ {
 			for k := 0; k < h; k++ {
 				c := Cell{
-					Ch: ' ',
+					Ch: bc.CellChar,
 					Bg: bc.BarColor,
 				}
 				if bc.BarColor == ColorDefault { // when color is default, space char treated as transparent!


### PR DESCRIPTION
What
===
Make BarChart cell character configurable.

Why
===
So that it can be set to a non-space character, which can be useful in
some situations. For example, it allows the barcharts to be used as
ASCII art and copy-pastable.

Example
===
https://github.com/leighmcculloch/keywords