### PR TITLE
Added a EvtStream member function ResetHandlers()

### DIFF
--- a/events.go
+++ b/events.go
@@ -221,6 +221,13 @@ func findMatch(mux map[string]func(Event), path string) string {
 	return pattern
 
 }
+// Remove all existing defined Handlers from the map
+func (es *EvtStream) ResetHandlers() {
+	for Path, _ := range es.Handlers {
+		delete(es.Handlers, Path)
+	}
+	return
+}
 
 func (es *EvtStream) match(path string) string {
 	return findMatch(es.Handlers, path)


### PR DESCRIPTION
A feature that I missed, it clears all the defined termui.Handle() calls.

Also a cleaner fix for https://github.com/gizak/termui/issues/92