### PR TITLE
linechart: reset bottomValue and topValue on each calculation

### DIFF
--- a/linechart.go
+++ b/linechart.go
@@ -223,6 +223,9 @@ func (lc *LineChart) calcLayout() {
 	lc.minY = lc.Data[0]
 	lc.maxY = lc.Data[0]
 
+	lc.bottomValue = lc.minY
+	lc.topValue = lc.maxY
+
 	// valid visible range
 	vrange := lc.innerArea.Dx()
 	if lc.Mode == "braille" {


### PR DESCRIPTION
previous behavior remembered over-all bottom and top values, greatly skewing the linechart if it once saw an abnormal number
