### PR TITLE
linechart: remember if data labels were automatically calculated

### DIFF
--- a/linechart.go
+++ b/linechart.go
@@ -69,6 +69,7 @@ type LineChart struct {
 	labelYSpace   int
 	maxY          float64
 	minY          float64
+	autoLabels    bool
 }
 
 // NewLineChart returns a new LineChart with current theme.
@@ -211,7 +212,8 @@ func (lc *LineChart) calcLabelY() {
 
 func (lc *LineChart) calcLayout() {
 	// set datalabels if it is not provided
-	if lc.DataLabels == nil || len(lc.DataLabels) == 0 {
+	if (lc.DataLabels == nil || len(lc.DataLabels) == 0) || lc.autoLabels {
+		lc.autoLabels = true
 		lc.DataLabels = make([]string, len(lc.Data))
 		for i := range lc.Data {
 			lc.DataLabels[i] = fmt.Sprint(i)


### PR DESCRIPTION
The issue exists when calcLayout() is ran on the linechart and linechart.Data is non-empty. Initial labels will be created and if linechart.Data later grows, this will never be accounted for because of the checks here

```go
func (lc *LineChart) calcLayout() {
	// set datalabels if it is not provided
	if lc.DataLabels == nil || len(lc.DataLabels) == 0 {
```