### PR TITLE
Fix example program in doc.go

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -22,6 +22,8 @@ A simplest example:
         g.BorderLabel = "Gauge"
 
         ui.Render(g)
+
+        ui.Loop()
     }
 */
 package termui


### PR DESCRIPTION
I was trying to learn how to use this library from reading the godocs. The given example just immediately exits because it does not include a call to `Loop`.