### PR TITLE
Expose ResetHandlers()

### DIFF
--- a/events.go
+++ b/events.go
@@ -274,6 +274,10 @@ func Handle(path string, handler func(Event)) {
 	DefaultEvtStream.Handle(path, handler)
 }
 
+func ResetHandlers() {
+	DefaultEvtStream.ResetHandlers()
+}
+
 func Loop() {
 	DefaultEvtStream.Loop()
 }


### PR DESCRIPTION
`ResetHandlers()` was added in PR [#98](https://github.com/gizak/termui/pull/98), it's a very appreciated feature but it is not exposed the same way `Handle()`, `Loop()` or others are exposed through a regular function. It's only exposed through a method and hence cannot be called with something like `termui.ResetHandlers()`, this PR aim to achieve this.