### PR TITLE
Add listbox widget with scroll indicators

### DIFF
--- a/_example/listbox.go
+++ b/_example/listbox.go
@@ -1,0 +1,53 @@
+// Copyright 2017 Zack Guo <zack.y.guo@gmail.com>. All rights reserved.
+// Use of this source code is governed by a MIT license that can
+// be found in the LICENSE file.
+//
+// Portions copyright 2017 Patrick Devine <patrick@immense.ly>
+
+// +build ignore
+
+package main
+
+import ui "github.com/gizak/termui"
+
+func main() {
+	err := ui.Init()
+	if err != nil {
+		panic(err)
+	}
+	defer ui.Close()
+
+	strs := []ui.Item{
+		ui.Item{"github.com/gizak/termui", "github.com/gizak/termui"},
+		ui.Item{"你好，世界", "[你好，世界](fg-blue)"},
+		ui.Item{"こんにちは世界", "[こんにちは世界](fg-red)"},
+		ui.Item{"color output", "[color output](fg-white,bg-green)"},
+		ui.Item{"output.go", "output.go"},
+		ui.Item{"random_out.go", "random_out.go"},
+		ui.Item{"dashboard.go", "dashboard.go"},
+		ui.Item{"nsf/termbox-go", "nsf/termbox-go"},
+	}
+
+	ls := ui.NewListBox()
+	ls.Items = strs
+	ls.ItemFgColor = ui.ColorYellow
+	ls.BorderLabel = "List"
+	ls.Height = 7
+	ls.Width = 20
+	ls.Y = 0
+
+	ui.Render(ls)
+	ui.Handle("/sys/kbd/q", func(ui.Event) {
+		ui.StopLoop()
+	})
+	ui.Handle("/sys/kbd/<up>", func(ui.Event) {
+		ls.Up()
+		ui.Render(ls)
+	})
+	ui.Handle("/sys/kbd/<down>", func(ui.Event) {
+		ls.Down()
+		ui.Render(ls)
+	})
+	ui.Loop()
+
+}

--- a/listbox.go
+++ b/listbox.go
@@ -1,0 +1,99 @@
+// Copyright 2017 Zack Guo <zack.y.guo@gmail.com>. All rights reserved.
+// Use of this source code is governed by a MIT license that can
+// be found in the LICENSE file.
+//
+// Portions copyright 2017 Patrick Devine <patrick@immense.ly>
+
+package termui
+
+// List displays []Item as its items (items are pairs of text and values),
+// it has a Overflow option (default is "hidden"), when set to "hidden",
+// the item exceeding List's width is truncated, but when set to "wrap",
+// the overflowed text breaks into next line.
+
+type Item struct {
+	ItemVal string
+	Text    string
+}
+
+type ListBox struct {
+	Block
+	Items       []Item
+	ItemFgColor Attribute
+	ItemBgColor Attribute
+	Selected    int
+	lowerBound  int
+}
+
+// NewList returns a new *List with current theme.
+func NewListBox() *ListBox {
+	l := &ListBox{Block: *NewBlock()}
+	l.ItemFgColor = ThemeAttr("list.item.fg")
+	l.ItemBgColor = ThemeAttr("list.item.bg")
+	l.Selected = 0
+	l.lowerBound = 0
+	return l
+}
+
+// Buffer implements Bufferer interface.
+func (l *ListBox) Buffer() Buffer {
+	buf := l.Block.Buffer()
+
+	trimItems := l.GetItemsStrs()
+	totalItems := len(l.GetItemsStrs())
+	if len(trimItems) > l.innerArea.Dy() {
+		trimItems = trimItems[l.lowerBound : l.innerArea.Dy()+l.lowerBound]
+	}
+	for i, v := range trimItems {
+		var cs []Cell
+		if i+l.lowerBound == l.Selected {
+			cs = DTrimTxCls(DefaultTxBuilder.Build(v, l.ItemBgColor, l.ItemFgColor), l.innerArea.Dx())
+		} else {
+			cs = DTrimTxCls(DefaultTxBuilder.Build(v, l.ItemFgColor, l.ItemBgColor), l.innerArea.Dx())
+		}
+		j := 0
+		for _, vv := range cs {
+			w := vv.Width()
+			buf.Set(l.innerArea.Min.X+j, l.innerArea.Min.Y+i, vv)
+			j += w
+		}
+	}
+	// display scroll arrows
+	if l.lowerBound > 0 {
+		buf.Set(l.innerArea.Dx(), 1, Cell{Ch: '^'})
+	}
+	if totalItems > l.lowerBound+l.innerArea.Dy() {
+		buf.Set(l.innerArea.Dx(), l.innerArea.Dy(), Cell{Ch: 'v'})
+	}
+	return buf
+}
+
+func (l *ListBox) GetItemsStrs() []string {
+	var strs []string
+	for _, item := range l.Items {
+		strs = append(strs, item.Text)
+	}
+	return strs
+}
+
+func (l *ListBox) Up() {
+	if l.Selected > 0 {
+		l.Selected -= 1
+		if l.Selected < l.lowerBound {
+			l.lowerBound -= 1
+		}
+	}
+}
+
+func (l *ListBox) Down() {
+	if l.Selected < len(l.Items)-1 {
+		l.Selected += 1
+		if l.Selected >= l.innerArea.Dy()+l.lowerBound {
+			l.lowerBound += 1
+		}
+	}
+}
+
+func (l *ListBox) Current() Item {
+	return l.Items[l.Selected]
+}


### PR DESCRIPTION
Creates a ListBox widget which can be scrolled up/down with content indicators.

<img width="152" alt="screen shot 2017-05-06 at 11 18 30 am" src="https://cloud.githubusercontent.com/assets/75239/25774930/d3302064-324d-11e7-8746-5c13df0773ea.png">

You can move the highlighted selection w/ the up/down keys.