### PR TITLE
Init() cleanly after Close()

### DIFF
--- a/events.go
+++ b/events.go
@@ -139,7 +139,7 @@ func NewSysEvtCh() chan Event {
 	return ec
 }
 
-var DefaultEvtStream = NewEvtStream()
+var DefaultEvtStream *EvtStream
 
 type EvtStream struct {
 	sync.RWMutex

--- a/render.go
+++ b/render.go
@@ -33,6 +33,7 @@ func Init() error {
 	if err := tm.Init(); err != nil {
 		return err
 	}
+	DefaultEvtStream = NewEvtStream()
 
 	sysEvtChs = make([]chan Event, 0)
 	go hookTermboxEvt()


### PR DESCRIPTION
This is not the greatest or most beautiful solution to #100, but it does the job.

It's basically saying: "Hey, Garbage Collector, take care of cleaning up for me, will ya?"

Any improvements are welcome, but I've tried freeing up pretty much everything in DefaultEvtStream to avoid discarding it like a madman, yet it seems that the Handles never get properly freed (probably due to my lack of understanding of the system).