### PR TITLE
Fix panic on table row count change

### DIFF
--- a/table.go
+++ b/table.go
@@ -75,10 +75,10 @@ func (table *Table) Analysis() [][]Cell {
 		return rowCells
 	}
 
-	if len(table.FgColors) == 0 {
+	if len(table.FgColors) == len(table.Rows) {
 		table.FgColors = make([]Attribute, len(table.Rows))
 	}
-	if len(table.BgColors) == 0 {
+	if len(table.BgColors) == len(table.Rows) {
 		table.BgColors = make([]Attribute, len(table.Rows))
 	}
 


### PR DESCRIPTION
This change will allow for dynamic row counts.

When the number of rows is greater than the original rows length, these statements don't get executed and the two ifs in the loop over the rows will index out-of-range.