### PR TITLE
Added more scrolling options to list widget.

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -112,6 +112,10 @@ func RoundFloat64(x float64) float64 {
 	return math.Floor(x + 0.5)
 }
 
+func FloorFloat64(x float64) float64 {
+	return math.Floor(x)
+}
+
 func AbsInt(x int) int {
 	if x >= 0 {
 		return x

--- a/widgets/list.go
+++ b/widgets/list.go
@@ -96,26 +96,46 @@ func (self *List) ScrollDown() {
 	}
 }
 
+// Scrolls by amount given. If amount is < 0, then scroll up.
+// There is no need to set self.topRow, as this will be set automatically when drawn,
+// since if the selected item is off screen then the topRow variable will change accordingly.
+func (self *List) scrollAmount(amount int) {
+	if len(self.Rows)-int(self.SelectedRow) <= amount {
+		self.SelectedRow = uint(len(self.Rows)-1)
+	} else if int(self.SelectedRow)+amount < 0 {
+		self.SelectedRow = 0
+	} else {
+		self.SelectedRow += uint(amount)
+	}
+}
+
 // PageUp scrolls up one whole page.
 func (self *List) PageUp() {
-	// if on the first 'page'
-	if int(self.SelectedRow)-self.Inner.Dy() < 0 {
-		// go to the top
-		self.topRow = 0
+	// If an item is selected below top row, then go to the top row.
+	if self.SelectedRow > self.topRow {
+		self.SelectedRow = self.topRow
 	} else {
-		self.topRow = uint(MaxInt(int(self.topRow)-self.Inner.Dy(), 0))
+		self.scrollAmount(-self.Inner.Dy())
 	}
-	self.SelectedRow = self.topRow
 }
 
 // PageDown scolls down one whole page.
 func (self *List) PageDown() {
-	// if on last 'page'
-	if len(self.Rows)-int(self.topRow) <= self.Inner.Dy() {
-		// select last item
-		self.SelectedRow = uint(len(self.Rows) - 1)
-	} else {
-		self.topRow += uint(self.Inner.Dy())
-		self.SelectedRow = self.topRow
-	}
+	self.scrollAmount(self.Inner.Dy())
+}
+
+func (self *List) HalfPageUp() {
+	self.scrollAmount(-int(FloorFloat64(float64(self.Inner.Dy())/2)))
+}
+
+func (self *List) HalfPageDown() {
+	self.scrollAmount(int(FloorFloat64(float64(self.Inner.Dy())/2)))
+}
+
+func (self *List) ScrollTop() {
+	self.SelectedRow = 0
+}
+
+func (self *List) ScrollBottom() {
+	self.SelectedRow = uint(len(self.Rows)-1)
 }


### PR DESCRIPTION
Added `HalfPageUp`, `HalfPageDown`, `ScrollTop` and `ScrollBottom` functions. I also added a `scrollAmount` function, which is not exported in the package since I was not sure if you wanted to make that available to the user. `scrollAmount` scrolls by the number of rows given. If the number is negative, then it scrolls up, if the number is positive then it will scroll down.
I did also have to add a floor function in `uitls.go` for the `HalfPageUp/Down` functions.

For issue #219 