### PR TITLE
Table render improvements

### DIFF
--- a/_examples/table.go
+++ b/_examples/table.go
@@ -56,7 +56,7 @@ func main() {
 	table3.SetRect(0, 30, 70, 20)
 	table3.FillRow = true
 	table3.RowStyles[0] = ui.NewStyle(ui.ColorWhite, ui.ColorBlack, ui.ModifierBold)
-	table3.RowStyles[2] = ui.NewStyle(ui.ColorRed)
+	table3.RowStyles[2] = ui.NewStyle(ui.ColorWhite, ui.ColorRed, ui.ModifierBold)
 	table3.RowStyles[3] = ui.NewStyle(ui.ColorYellow)
 
 	ui.Render(table3)

--- a/widgets/table.go
+++ b/widgets/table.go
@@ -100,13 +100,16 @@ func (self *Table) Draw(buf *Buffer) {
 
 		// draw vertical separators
 		separatorStyle := self.Block.BorderStyle
-		if self.FillRow {
-			separatorStyle.Bg = rowStyle.Bg
-		}
 
 		separatorXCoordinate := self.Inner.Min.X
 		verticalCell := NewCell(VERTICAL_LINE, separatorStyle)
-		for _, width := range columnWidths {
+		for i, width := range columnWidths {
+			if self.FillRow && i < len(columnWidths)-1 {
+				verticalCell.Style.Bg = rowStyle.Bg
+			} else {
+				verticalCell.Style.Bg = self.Block.BorderStyle.Bg
+			}
+
 			separatorXCoordinate += width
 			buf.SetCell(verticalCell, image.Pt(separatorXCoordinate, yCoordinate))
 			separatorXCoordinate++


### PR DESCRIPTION
This PR does two things:

- Sets the separator colour to that of the `Block`
- Allows overriding styles of individual rows

This introduces some configuration that is similar to what was in before the refactor, and allows individual rows to be styled, including for example headers.

The example provided here renders the following:

![image](https://user-images.githubusercontent.com/427747/52141767-b0fa2980-264e-11e9-8679-6afaa9dd8a6c.png)

