### PR TITLE
selected rows in list should merge style with inline style

### DIFF
--- a/style_parser.go
+++ b/style_parser.go
@@ -63,7 +63,7 @@ func readStyle(runes []rune, defaultStyle Style) Style {
 			case tokenBg:
 				style.Bg = StyleParserColorMap[pair[1]]
 			case tokenModifier:
-				style.Modifier = modifierMap[pair[1]]
+				style.Modifier |= modifierMap[pair[1]]
 			}
 		}
 	}

--- a/widgets/list.go
+++ b/widgets/list.go
@@ -44,15 +44,17 @@ func (self *List) Draw(buf *Buffer) {
 
 	// draw rows
 	for row := self.topRow; row < len(self.Rows) && point.Y < self.Inner.Max.Y; row++ {
-		cells := ParseStyles(self.Rows[row], self.TextStyle)
+		var cells []Cell
+		if row == self.SelectedRow {
+			cells = ParseStyles(self.Rows[row], self.SelectedRowStyle)
+		} else {
+			cells = ParseStyles(self.Rows[row], self.TextStyle)
+		}
 		if self.WrapText {
 			cells = WrapCells(cells, uint(self.Inner.Dx()))
 		}
 		for j := 0; j < len(cells) && point.Y < self.Inner.Max.Y; j++ {
 			style := cells[j].Style
-			if row == self.SelectedRow {
-				style = self.SelectedRowStyle
-			}
 			if cells[j].Rune == '\n' {
 				point = image.Pt(self.Inner.Min.X, point.Y+1)
 			} else {


### PR DESCRIPTION
List SelectedRowStyle should be merged with inline styles. This change does two things:
1. Use ParseStyles for SelectedRowStyle.
2. Merge modifiers in readStyle instead of inline styles clearing any default modifiers.

I'm not sure if it was intended for SelectedRowStyle to completely override the inline styles. If it was, please feel free to disregard and reject this pull request 😃 