### PR TITLE
Wip/input widget - Add Text() and RawText() functions to textbox widget

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.2
 	github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7
 	github.com/nsf/termbox-go v0.0.0-20190121233118-02980233997d
+	github.com/stretchr/testify v1.3.0
 	golang.org/x/arch v0.0.0-20181203225421-5a4828bb7045 // indirect
 	golang.org/x/crypto v0.0.0-20190123085648-057139ce5d2b // indirect
 	golang.org/x/sys v0.0.0-20190124100055-b90733256f2e // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/cjbassi/drawille-go v0.0.0-20190126131713-27dc511fe6fd h1:XtfPmj9tQRilnrEmI1HjQhxXWRhEM+m8CACtaMJE/kM=
 github.com/cjbassi/drawille-go v0.0.0-20190126131713-27dc511fe6fd/go.mod h1:vjcQJUZJYD3MeVGhtZXSMnCHfUNZxsyYzJt90eCYxK4=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/pprof v0.0.0-20190109223431-e84dfd68c163 h1:beB+Da4k9B1zmgag78k3k1Bx4L/fdWr5FwNa0f8RxmY=
 github.com/google/pprof v0.0.0-20190109223431-e84dfd68c163/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6 h1:UDMh68UUwekSh5iP2OMhRRZJiiBccgV7axzUG8vi56c=
@@ -10,6 +12,11 @@ github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 h1:DpOJ2HYzC
 github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/nsf/termbox-go v0.0.0-20190121233118-02980233997d h1:x3S6kxmy49zXVVyhcnrFqxvNVCBPb2KZ9hV2RBdS840=
 github.com/nsf/termbox-go v0.0.0-20190121233118-02980233997d/go.mod h1:IuKpRQcYE1Tfu+oAQqaLisqDeXgjyyltCfsaoYN18NQ=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 golang.org/x/arch v0.0.0-20181203225421-5a4828bb7045 h1:Pn8fQdvx+z1avAi7fdM2kRYWQNxGlavNDSyzrQg2SsU=
 golang.org/x/arch v0.0.0-20181203225421-5a4828bb7045/go.mod h1:cYlCBUl1MsqxdiKgmc4uh7TxZfWSFLOGSRR090WDxt8=
 golang.org/x/crypto v0.0.0-20190123085648-057139ce5d2b h1:Elez2XeF2p9uyVj0yEUDqQ56NFcDtcBNkYP7yv8YbUE=

--- a/style.go
+++ b/style.go
@@ -1,5 +1,7 @@
 package termui
 
+import "strings"
+
 // Color is an integer from -1 to 255
 // -1 = ColorClear
 // 0-255 = Xterm colors
@@ -62,4 +64,23 @@ func NewStyle(fg Color, args ...interface{}) Style {
 		bg,
 		modifier,
 	}
+}
+
+//String returns a string representation of a Style
+func (self Style) String() string {
+	styles := make([]string, 0)
+
+	if color, ok := textColorMap[self.Fg]; ok  && self.Fg !=  StyleClear.Fg {
+		styles = append(styles, tokenFg + tokenValueSeparator + color)
+	}
+
+	if color, ok := textColorMap[self.Bg]; ok && self.Bg !=  StyleClear.Bg {
+		styles = append(styles, tokenBg + tokenValueSeparator + color)
+	}
+
+	if mod, ok := textModifierMap[self.Modifier]; ok  && self.Modifier !=  StyleClear.Modifier {
+		styles = append(styles, tokenModifier + tokenValueSeparator + mod)
+	}
+
+	return strings.Join(styles, tokenItemSeparator)
 }

--- a/style_parser.go
+++ b/style_parser.go
@@ -44,10 +44,28 @@ var StyleParserColorMap = map[string]Color{
 	"magenta": ColorMagenta,
 }
 
+var textColorMap = map[Color]string{
+	ColorRed: "red",
+	ColorBlue: "blue",
+	ColorBlack: "black",
+	ColorCyan: "cyan",
+	ColorYellow: "yellow",
+	ColorWhite: "white",
+	ColorClear: "clear",
+	ColorGreen: "green",
+	ColorMagenta: "magenta",
+}
+
 var modifierMap = map[string]Modifier{
 	"bold":      ModifierBold,
 	"underline": ModifierUnderline,
 	"reverse":   ModifierReverse,
+}
+
+var textModifierMap = map[Modifier]string{
+	ModifierBold: "bold",
+	ModifierUnderline: "underline",
+	ModifierReverse: "reverse",
 }
 
 // readStyle translates an []rune like `fg:red,mod:bold,bg:white` to a style

--- a/utils.go
+++ b/utils.go
@@ -231,7 +231,7 @@ func CellsToString(cells []Cell) string {
 }
 
 func writeText(sb *strings.Builder,runes []rune, currentStyle Style, defaultStyle Style) {
-	if currentStyle != defaultStyle {
+	if currentStyle != defaultStyle && currentStyle != StyleClear {
 		sb.WriteByte(tokenBeginStyledText)
 		sb.WriteString(string(runes))
 		sb.WriteByte(tokenEndStyledText)
@@ -272,7 +272,7 @@ func SplitCells(cells []Cell, r rune) [][]Cell {
 //JoinCells converts [][]cell to a []cell using r as line breaker
 func JoinCells(cells [][]Cell, r rune) []Cell {
 	joinCells := make([]Cell, 0)
-	lb := Cell{Rune: r}
+	lb := Cell{Rune: r, Style: StyleClear}
 	length := len(cells)
 
 	for i, cell := range cells {

--- a/widgets/textbox.go
+++ b/widgets/textbox.go
@@ -116,6 +116,20 @@ func (self *TextBox) SetText(input string) {
 	self.InsertText(input)
 }
 
+//GetText gets the text in string format along all its formatting tags
+func (self *TextBox) Text() string {
+	cells := JoinCells(self.text, '\n')
+
+	return CellsToStyledText(cells, self.TextStyle)
+}
+
+//GetText gets the text in string format without any formatting tags
+func (self *TextBox) RawText() string {
+	cells := JoinCells(self.text, '\n')
+
+	return CellsToText(cells)
+}
+
 func (self *TextBox) MoveCursorLeft() {
 	self.MoveCursor(self.cursorPoint.X-1, self.cursorPoint.Y)
 }

--- a/widgets/textbox_test.go
+++ b/widgets/textbox_test.go
@@ -39,7 +39,18 @@ func TestGetStyledText(t *testing.T) {
 
 //TestGetStyledText2 test styled text ending in a styled string
 func TestGetStyledText2(t *testing.T) {
-	text := "[red text](fg:red,mod:bold) more text [blue text](fg:blue,mod:bold) a [bit more](fg:black)"
+	text := "[red text](fg:red,mod:bold) more text [blue text](fg:blue,mod:bold) a [bit more](fg:green)"
+
+	tb := NewTextBox()
+	tb.SetText(text)
+
+	assert.Equal(t, text, tb.Text())
+}
+
+//TestGetStyledTextWithLBs test styled text with line breaks
+func TestGetStyledTextWithLBs(t *testing.T) {
+	text := `[red text](fg:red,mod:bold) more 
+ text [blue text](fg:blue,mod:bold) a [bit more](fg:green)`
 
 	tb := NewTextBox()
 	tb.SetText(text)

--- a/widgets/textbox_test.go
+++ b/widgets/textbox_test.go
@@ -1,0 +1,48 @@
+package widgets
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+)
+
+//TestGetRawText test simple string
+func TestGetRawText(t *testing.T) {
+	text := "My Sample RawText"
+	tb := NewTextBox()
+	tb.SetText(text)
+
+	assert.Equal(t, text, tb.RawText())
+}
+
+//TestGetRawTextWithLBs test line breaks in the text
+func TestGetRawTextWithLBs(t *testing.T) {
+	text := `My Sample RawText
+				with	
+				line 
+				breaks`
+
+	tb := NewTextBox()
+	tb.SetText(text)
+
+	assert.Equal(t, text, tb.RawText())
+}
+
+//TestGetStyledText test styled text
+func TestGetStyledText(t *testing.T) {
+	text := "[red text](fg:red,mod:bold) more text [blue text](fg:blue,mod:bold) a bit more"
+
+	tb := NewTextBox()
+	tb.SetText(text)
+
+	assert.Equal(t, text, tb.Text())
+}
+
+//TestGetStyledText2 test styled text ending in a styled string
+func TestGetStyledText2(t *testing.T) {
+	text := "[red text](fg:red,mod:bold) more text [blue text](fg:blue,mod:bold) a [bit more](fg:black)"
+
+	tb := NewTextBox()
+	tb.SetText(text)
+
+	assert.Equal(t, text, tb.Text())
+}


### PR DESCRIPTION
Hello @cjbassi,

Here is the pull request to add `Text()` and `RawText()` functions to textbox widget as discussed in the other thread. 

I added regular unit test file `textbox_test.go` which includes unit tests for these new functions only. I am not sure if you like that idea. Please let me know and I can remove it if required. 

The conversion from `[][]Cell` to a styled text only takes styles that are different from `StyleClear` and `TextStyle` (the default style for the given input box).

I am relatively new to golang, if there is anything that does not look ok to you please let me know and I am happy to do some refactoring. 