### PR TITLE
sixel implementation

### DIFF
--- a/_examples/image.go
+++ b/_examples/image.go
@@ -49,7 +49,7 @@ func main() {
 	defer ui.Close()
 
 	img := widgets.NewImage(nil)
-	img.SetRect(0, 0, 100, 50)
+	img.SetRect(10, 5, 40, 45)
 	index := 0
 	render := func() {
 		img.Image = images[index]

--- a/block.go
+++ b/block.go
@@ -27,6 +27,8 @@ type Block struct {
 	Title      string
 	TitleStyle Style
 
+	ANSIString string
+
 	sync.Mutex
 }
 
@@ -102,4 +104,9 @@ func (self *Block) SetRect(x1, y1, x2, y2 int) {
 // GetRect implements the Drawable interface.
 func (self *Block) GetRect() image.Rectangle {
 	return self.Rectangle
+}
+
+// GetANSIString implements the Drawable interface.
+func (self *Block) GetANSIString() string {
+	return self.ANSIString
 }

--- a/render.go
+++ b/render.go
@@ -5,6 +5,7 @@
 package termui
 
 import (
+	"fmt"
 	"image"
 	"sync"
 
@@ -16,6 +17,7 @@ type Drawable interface {
 	SetRect(int, int, int, int)
 	Draw(*Buffer)
 	sync.Locker
+	GetANSIString() string
 }
 
 func Render(items ...Drawable) {
@@ -32,6 +34,12 @@ func Render(items ...Drawable) {
 					tb.Attribute(cell.Style.Fg+1)|tb.Attribute(cell.Style.Modifier), tb.Attribute(cell.Style.Bg+1),
 				)
 			}
+		}
+
+		// draw the image over the already filled cells
+		if ansiString := item.GetANSIString(); len(ansiString) > 0 {
+			fmt.Printf("%s", ansiString)
+			continue
 		}
 	}
 	tb.Flush()

--- a/widgets/image.go
+++ b/widgets/image.go
@@ -1,12 +1,25 @@
 // Copyright 2017 Zack Guo <zack.y.guo@gmail.com>. All rights reserved.
+// Copyright 2018,2019 Simon R. Lehn. All rights reserved.
 // Use of this source code is governed by a MIT license that can
 // be found in the LICENSE file.
 
 package widgets
 
 import (
+	"bytes"
+	"encoding/base64"
+	"errors"
+	"fmt"
 	"image"
 	"image/color"
+	"image/png" // for encoding for iTerm2
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/disintegration/imaging"
+	"github.com/mattn/go-sixel"
+	"github.com/mattn/go-tty"
 
 	. "github.com/gizak/termui/v3"
 )
@@ -19,6 +32,34 @@ type Image struct {
 	MonochromeInvert    bool
 }
 
+var (
+	sixelCapable, isIterm2                      bool
+	charBoxWidthInPixels, charBoxHeightInPixels float64
+	lastImageDimensions                         image.Rectangle
+)
+
+func init() {
+	// example query: "\033[0c"
+	// possible answer from the terminal (here xterm): "\033[[?63;1;2;4;6;9;15;22c"
+	// the "4" signals that the terminal is capable of sixel
+	termCapabilities := queryTerm("\033[0c")
+	for i, cap := range termCapabilities {
+		if i == 0 || i == len(termCapabilities)-1 {
+			continue
+		}
+		if string(cap) == `4` {
+			sixelCapable = true
+
+			// terminal character box size measured in pixels
+			charBoxWidthInPixels, charBoxHeightInPixels = getTermCharBoxSize()
+		}
+	}
+	// # https://superuser.com/a/683971
+	if os.Getenv("TERM_PROGRAM") == "iTerm.app" {
+		isIterm2 = true
+	}
+}
+
 func NewImage(img image.Image) *Image {
 	return &Image{
 		Block:               *NewBlock(),
@@ -28,6 +69,22 @@ func NewImage(img image.Image) *Image {
 }
 
 func (self *Image) Draw(buf *Buffer) {
+	// draw with ANSI escape strings
+	// sixel / iTerm2
+	if sixelCapable || isIterm2 {
+		////if true {
+		if err := self.drawANSI(buf); err == nil {
+			return
+		}
+	}
+
+	// urxvt pixbuf / ...
+
+	// fall back - draw with box characters
+	self.drawFallBack(buf)
+}
+
+func (self *Image) drawFallBack(buf *Buffer) {
 	self.Block.Draw(buf)
 
 	if self.Image == nil {
@@ -201,4 +258,199 @@ func blocksChar(ul, ur, ll, lr colorAverager, threshold uint8, invert bool) rune
 		index |= 8
 	}
 	return IRREGULAR_BLOCKS[index]
+}
+
+func (self *Image) drawANSI(buf *Buffer) (err error) {
+	self.Block.Draw(buf)
+
+	// get dimensions //
+	// terminal size measured in cells
+	imageWidthInColumns := self.Inner.Dx()
+	imageHeightInRows := self.Inner.Dy()
+
+	// calculate image size in pixels
+	imageWidthInPixels := int(float64(imageWidthInColumns) * charBoxWidthInPixels)
+	imageHeightInPixels := int(float64(imageHeightInRows) * charBoxHeightInPixels)
+	if imageWidthInPixels == 0 || imageHeightInPixels == 0 {
+		return fmt.Errorf("could not calculate the image size in pixels")
+	}
+
+	termWidthInColumns, termHeightInRows := getTermSizeInChars()
+
+	// handle only partially displayed image
+	// otherwise we get scrolling
+	var needsCrop bool
+	imgCroppedWidth := imageWidthInPixels
+	imgCroppedHeight := imageHeightInPixels
+	if self.Max.X > int(termWidthInColumns)+1 {
+		imgCroppedWidth = int(float64(int(termWidthInColumns)-self.Inner.Min.X-1) * charBoxWidthInPixels)
+		needsCrop = true
+	}
+	if self.Max.Y > int(termHeightInRows)+1 {
+		imgCroppedHeight = int(float64(int(termHeightInRows)-self.Inner.Min.Y-1) * charBoxHeightInPixels)
+		needsCrop = true
+	}
+
+	// this is meant for comparison and for positioning in the ANSI string
+	// the Min values are in cells while the Max values are in pixels
+	imageDimensions := image.Rectangle{Min: image.Point{X: self.Inner.Min.X + 1, Y: self.Inner.Min.Y + 1}, Max: image.Point{X: imgCroppedWidth, Y: imgCroppedHeight}}
+	// print saved ANSI string if image size and position didn't change
+	if imageDimensions == lastImageDimensions {
+		return nil
+	}
+
+	// resize and crop the image //
+	img := imaging.Resize(self.Image, imageWidthInPixels, imageHeightInPixels, imaging.Lanczos)
+	if needsCrop {
+		img = imaging.Crop(img, image.Rectangle{Min: image.Point{X: 0, Y: 0}, Max: image.Point{X: imgCroppedWidth, Y: imgCroppedHeight}})
+	}
+
+	if img.Bounds().Dx() == 0 || img.Bounds().Dy() == 0 {
+		return fmt.Errorf("image size in pixels is 0")
+	}
+
+	// iTerm2
+	// https://www.iterm2.com/documentation-images.html
+	if isIterm2 {
+		buf := new(bytes.Buffer)
+		if err = png.Encode(buf, img); err != nil {
+			goto skipIterm2
+		}
+		imgBase64 := base64.StdEncoding.EncodeToString(buf.Bytes())
+		nameBase64 := base64.StdEncoding.EncodeToString([]byte(self.Block.Title))
+		// 0 for stretching - 1 for no stretching
+		noStretch := 0
+		// for width, height:   "auto"   ||   N: N character cells   ||   Npx: N pixels   ||   N%: N percent of terminal width/height
+		self.Block.ANSIString = fmt.Sprintf("\033]1337;File=name=%s;inline=1;height=%d;width=%d;preserveAspectRatio=%d:%s\a", nameBase64, imageDimensions.Max.Y, nameBase64, imageDimensions.Max.X, noStretch, imgBase64)
+
+		return nil
+	}
+skipIterm2:
+
+	if sixelCapable {
+		byteBuf := new(bytes.Buffer)
+		enc := sixel.NewEncoder(byteBuf)
+		enc.Dither = true
+		if err := enc.Encode(img); err != nil {
+			return err
+		}
+
+		// position where the image should appear (upper left corner)
+		self.Block.ANSIString = fmt.Sprintf("\033[%d;%dH%s", imageDimensions.Min.Y, imageDimensions.Min.X, byteBuf.String())
+		// test string "HI"
+		// self.Block.ANSIString = fmt.Sprintf("\033[%d;%dH%s", self.Inner.Min.Y+1, self.Inner.Min.X+1, "\033Pq#0;2;0;0;0#1;2;100;100;0#2;2;0;100;0#1~~@@vv@@~~@@~~$#2??}}GG}}??}}??-#1!14@\033\\")
+
+		return nil
+	}
+
+	return errors.New("no method applied for ANSI drawing")
+}
+
+func getTermCharBoxSize() (x, y float64) {
+	if cx, cy := getTermSizeInChars(); cx != 0 && cy != 0 {
+		px, py := getTermSizeInPixels()
+		x = float64(px) / float64(cx)
+		y = float64(py) / float64(cy)
+	}
+	return
+}
+
+func getTermSizeInChars() (x, y uint) {
+	// query terminal size in character boxes
+	// answer: <termHeightInRows>;<termWidthInColumns>t
+	q := queryTerm("\033[18t")
+
+	if len(q) != 3 {
+		return
+	}
+
+	if yy, err := strconv.Atoi(string(q[1])); err == nil {
+		if xx, err := strconv.Atoi(string(q[2])); err == nil {
+			x = uint(xx)
+			y = uint(yy)
+		} else {
+			return
+		}
+	} else {
+		return
+	}
+
+	return
+}
+
+func getTermSizeInPixels() (x, y uint) {
+	// query terminal size in pixels
+	// answer: <termHeightInPixels>;<termWidthInPixels>t
+	q := queryTerm("\033[14t")
+
+	if len(q) != 3 {
+		return
+	}
+
+	if yy, err := strconv.Atoi(string(q[1])); err == nil {
+		if xx, err := strconv.Atoi(string(q[2])); err == nil {
+			x = uint(xx)
+			y = uint(yy)
+		} else {
+			return
+		}
+	} else {
+		return
+	}
+
+	return
+}
+
+func queryTerm(qs string) (ret [][]rune) {
+	// temporary fix for xterm
+	// otherwise TUI wouldn't react to any further events
+	// resizing still works though
+	if len(os.Getenv("XTERM_VERSION")) > 0 {
+		return
+	}
+
+	var b []rune
+
+	tty, err := tty.Open()
+	if err != nil {
+		return
+	}
+	defer tty.Close()
+
+	ch := make(chan bool, 1)
+
+	go func() {
+		// query terminal
+		fmt.Printf(qs)
+
+		for {
+			r, err := tty.ReadRune()
+			if err != nil {
+				return
+			}
+			// handle key event
+			switch r {
+			case 'c', 't':
+				ret = append(ret, b)
+				goto afterLoop
+			case '?', ';':
+				ret = append(ret, b)
+				b = []rune{}
+			default:
+				b = append(b, r)
+			}
+		}
+	afterLoop:
+		ch <- true
+	}()
+
+	timer := time.NewTimer(50 * time.Millisecond)
+	defer timer.Stop()
+
+	select {
+	case <-ch:
+		defer close(ch)
+	case <-timer.C:
+	}
+	return
 }


### PR DESCRIPTION
addresses #213 

This is **unfinished** and i wish that someone else takes over.
Most of the testing was done with mlterm.

☑ sixel support implemented
☑ check for sixel support (only ANSI terminals considered) otherwise use fallback
☑ update Render()
☑ handle partially shown images
☐ iTerm2 img support:test version implemented but completely untested (no OSX system available) [doc](https://www.iterm2.com/documentation-images.html)
☐ get correct dimensions from xterm
☐ handle non-ANSI terminals (cmd.exe, ...)
☐ test more (pseudo) terminals

---
### Terminals with sixel support
**mlterm**, mintty (cygwin terminal), xterm with configuration

https://github.com/saitoha/libsixel/#terminal-requirements
---
![demo](https://user-images.githubusercontent.com/48837958/55262907-b4d1b300-526f-11e9-9d8d-da7d39d54dac.gif)
