### PR TITLE
Add an "Active" member for Block to allow "focusable" widgets

### DIFF
--- a/_examples/list.go
+++ b/_examples/list.go
@@ -33,39 +33,70 @@ func main() {
 		"[8] bar",
 		"[9] baz",
 	}
+	l.ActiveBorderStyle = ui.NewStyle(ui.ColorRed)
 	l.TextStyle = ui.NewStyle(ui.ColorYellow)
 	l.WrapText = false
 	l.SetRect(0, 0, 25, 8)
+	l.Active = true
 
-	ui.Render(l)
+	l2 := widgets.NewList()
+	l2.Title = "List 2"
+	l2.Rows = []string{
+		"foo",
+		"bar",
+		"baz",
+	}
+	l2.ActiveBorderStyle = ui.NewStyle(ui.ColorRed)
+	l2.TextStyle = ui.NewStyle(ui.ColorYellow)
+	l2.WrapText = false
+	l2.SetRect(28, 0, 53, 8)
+
+	uiWidgets := []*widgets.List{l, l2}
+
+	for _, w := range(uiWidgets) {
+		ui.Render(w)
+	}
+
+	var activeWidget *widgets.List
 
 	previousKey := ""
 	uiEvents := ui.PollEvents()
 	for {
+		for _, w := range(uiWidgets) {
+			if w.Active {
+				activeWidget = w
+				break
+			}
+		}
+
 		e := <-uiEvents
 		switch e.ID {
 		case "q", "<C-c>":
 			return
 		case "j", "<Down>":
-			l.ScrollDown()
+			activeWidget.ScrollDown()
 		case "k", "<Up>":
-			l.ScrollUp()
+			activeWidget.ScrollUp()
 		case "<C-d>":
-			l.ScrollHalfPageDown()
+			activeWidget.ScrollHalfPageDown()
 		case "<C-u>":
-			l.ScrollHalfPageUp()
+			activeWidget.ScrollHalfPageUp()
 		case "<C-f>":
-			l.ScrollPageDown()
+			activeWidget.ScrollPageDown()
 		case "<C-b>":
-			l.ScrollPageUp()
+			activeWidget.ScrollPageUp()
 		case "g":
 			if previousKey == "g" {
-				l.ScrollTop()
+				activeWidget.ScrollTop()
 			}
 		case "<Home>":
-			l.ScrollTop()
+			activeWidget.ScrollTop()
 		case "G", "<End>":
-			l.ScrollBottom()
+			activeWidget.ScrollBottom()
+		case "<Tab>":
+			for _, w := range(uiWidgets) {
+				w.Active = !w.Active
+			}
 		}
 
 		if previousKey == "g" {
@@ -74,6 +105,8 @@ func main() {
 			previousKey = e.ID
 		}
 
-		ui.Render(l)
+		for _, w := range(uiWidgets) {
+			ui.Render(w)
+		}
 	}
 }

--- a/_examples/tree.go
+++ b/_examples/tree.go
@@ -68,52 +68,78 @@ func main() {
 	}
 
 	l := widgets.NewTree()
+	l.ActiveBorderStyle = ui.NewStyle(ui.ColorRed)
+	l.Active = true
 	l.TextStyle = ui.NewStyle(ui.ColorYellow)
 	l.WrapText = false
 	l.SetNodes(nodes)
 
+	l2 := widgets.NewTree()
+	l2.ActiveBorderStyle = ui.NewStyle(ui.ColorRed)
+	l2.TextStyle = ui.NewStyle(ui.ColorYellow)
+	l2.WrapText = false
+	l2.SetNodes(nodes)
+
 	x, y := ui.TerminalDimensions()
 
-	l.SetRect(0, 0, x, y)
+	l.SetRect(0, 0, x/2, y)
+	l2.SetRect(x/2+1, 0, x, y)
 
-	ui.Render(l)
+	uiWidgets := []*widgets.Tree{l, l2}
+
+	for _, w := range uiWidgets {
+		ui.Render(w)
+	}
+
+	var activeWidget *widgets.Tree
 
 	previousKey := ""
 	uiEvents := ui.PollEvents()
 	for {
+                for _, w := range(uiWidgets) {
+                        if w.Active {
+                                activeWidget = w
+                                break
+                        }
+                }
+
 		e := <-uiEvents
 		switch e.ID {
 		case "q", "<C-c>":
 			return
 		case "j", "<Down>":
-			l.ScrollDown()
+			activeWidget.ScrollDown()
 		case "k", "<Up>":
-			l.ScrollUp()
+			activeWidget.ScrollUp()
 		case "<C-d>":
-			l.ScrollHalfPageDown()
+			activeWidget.ScrollHalfPageDown()
 		case "<C-u>":
-			l.ScrollHalfPageUp()
+			activeWidget.ScrollHalfPageUp()
 		case "<C-f>":
-			l.ScrollPageDown()
+			activeWidget.ScrollPageDown()
 		case "<C-b>":
-			l.ScrollPageUp()
+			activeWidget.ScrollPageUp()
 		case "g":
 			if previousKey == "g" {
-				l.ScrollTop()
+				activeWidget.ScrollTop()
 			}
 		case "<Home>":
-			l.ScrollTop()
+			activeWidget.ScrollTop()
 		case "<Enter>":
-			l.ToggleExpand()
+			activeWidget.ToggleExpand()
 		case "G", "<End>":
-			l.ScrollBottom()
+			activeWidget.ScrollBottom()
 		case "E":
-			l.ExpandAll()
+			activeWidget.ExpandAll()
 		case "C":
-			l.CollapseAll()
+			activeWidget.CollapseAll()
 		case "<Resize>":
 			x, y := ui.TerminalDimensions()
-			l.SetRect(0, 0, x, y)
+			l.SetRect(0, 0, x/2, y)
+			l2.SetRect(0, 0, x/2+1, y)
+		case "<Tab>":
+			l.Active = !l.Active
+			l2.Active = !l2.Active
 		}
 
 		if previousKey == "g" {
@@ -122,6 +148,8 @@ func main() {
 			previousKey = e.ID
 		}
 
-		ui.Render(l)
+		for _, w := range uiWidgets {
+			ui.Render(w)
+		}
 	}
 }

--- a/v3/block.go
+++ b/v3/block.go
@@ -14,8 +14,11 @@ import (
 // It implements all 3 of the methods needed for the `Drawable` interface.
 // Custom widgets will override the Draw method.
 type Block struct {
-	Border      bool
-	BorderStyle Style
+	Active            bool
+	ActiveBorderStyle Style
+
+	Border            bool
+	BorderStyle       Style
 
 	BorderLeft, BorderRight, BorderTop, BorderBottom bool
 
@@ -32,20 +35,27 @@ type Block struct {
 
 func NewBlock() *Block {
 	return &Block{
-		Border:       true,
-		BorderStyle:  Theme.Block.Border,
-		BorderLeft:   true,
-		BorderRight:  true,
-		BorderTop:    true,
-		BorderBottom: true,
+		Active:            false,
+		ActiveBorderStyle: Theme.Block.Border,
+		Border:            true,
+		BorderStyle:       Theme.Block.Border,
+		BorderLeft:        true,
+		BorderRight:       true,
+		BorderTop:         true,
+		BorderBottom:      true,
 
 		TitleStyle: Theme.Block.Title,
 	}
 }
 
 func (self *Block) drawBorder(buf *Buffer) {
-	verticalCell := Cell{VERTICAL_LINE, self.BorderStyle}
-	horizontalCell := Cell{HORIZONTAL_LINE, self.BorderStyle}
+	borderStyle := self.BorderStyle
+	if self.Active {
+		borderStyle = self.ActiveBorderStyle
+	}
+
+	verticalCell := Cell{VERTICAL_LINE, borderStyle}
+	horizontalCell := Cell{HORIZONTAL_LINE, borderStyle}
 
 	// draw lines
 	if self.BorderTop {
@@ -63,16 +73,16 @@ func (self *Block) drawBorder(buf *Buffer) {
 
 	// draw corners
 	if self.BorderTop && self.BorderLeft {
-		buf.SetCell(Cell{TOP_LEFT, self.BorderStyle}, self.Min)
+		buf.SetCell(Cell{TOP_LEFT, borderStyle}, self.Min)
 	}
 	if self.BorderTop && self.BorderRight {
-		buf.SetCell(Cell{TOP_RIGHT, self.BorderStyle}, image.Pt(self.Max.X-1, self.Min.Y))
+		buf.SetCell(Cell{TOP_RIGHT, borderStyle}, image.Pt(self.Max.X-1, self.Min.Y))
 	}
 	if self.BorderBottom && self.BorderLeft {
-		buf.SetCell(Cell{BOTTOM_LEFT, self.BorderStyle}, image.Pt(self.Min.X, self.Max.Y-1))
+		buf.SetCell(Cell{BOTTOM_LEFT, borderStyle}, image.Pt(self.Min.X, self.Max.Y-1))
 	}
 	if self.BorderBottom && self.BorderRight {
-		buf.SetCell(Cell{BOTTOM_RIGHT, self.BorderStyle}, self.Max.Sub(image.Pt(1, 1)))
+		buf.SetCell(Cell{BOTTOM_RIGHT, borderStyle}, self.Max.Sub(image.Pt(1, 1)))
 	}
 }
 


### PR DESCRIPTION
This change adds a new "Active" member to Block so that it can be used to tell whether a given widget is in focus or not. I added some examples to show how you can use it.

I wasn't sure if "Active" was the correct term here. GTK uses the term "Has Focus" which might be more appropriate.

This relates to #209 