### PR TITLE
Correct looking at wrong index for PreviousHeight in plot.go

### DIFF
--- a/v3/widgets/plot.go
+++ b/v3/widgets/plot.go
@@ -96,7 +96,7 @@ func (self *Plot) renderBraille(buf *Buffer, drawArea image.Rectangle, maxVal fl
 		}
 	case LineChart:
 		for i, line := range self.Data {
-			previousHeight := int((line[1] / maxVal) * float64(drawArea.Dy()-1))
+			previousHeight := int((line[i] / maxVal) * float64(drawArea.Dy()-1))
 			for j, val := range line[1:] {
 				height := int((val / maxVal) * float64(drawArea.Dy()-1))
 				canvas.SetLine(

--- a/v3/widgets/plot.go
+++ b/v3/widgets/plot.go
@@ -83,6 +83,12 @@ func (self *Plot) renderBraille(buf *Buffer, drawArea image.Rectangle, maxVal fl
 	switch self.PlotType {
 	case ScatterPlot:
 		for i, line := range self.Data {
+			previousHeight := 0
+      			if i == 0 {
+        			previousHeight = int((line[i] / maxVal) * float64(drawArea.Dy()-1))
+      			} else {
+        			previousHeight = int((line[i-1] / maxVal) * float64(drawArea.Dy()-1))
+      			}
 			for j, val := range line {
 				height := int((val / maxVal) * float64(drawArea.Dy()-1))
 				canvas.SetPoint(


### PR DESCRIPTION
Feel to reject this PR if I got the wrong Idea here, but this fixed one of my bugs.
To find `PreviousHeight`, `plot.go` looks at `line[1]` as a value, but this causes a crash if the line has only one value.

I suspect to find the previous height, we want to look at `line[i-1]`. I added this and a simple check to make sure we aren't on the first data point, in which case there is no "PreviousHeight".