### PR TITLE
Fix errors on line plots

### DIFF
--- a/v3/widgets/plot.go
+++ b/v3/widgets/plot.go
@@ -83,12 +83,6 @@ func (self *Plot) renderBraille(buf *Buffer, drawArea image.Rectangle, maxVal fl
 	switch self.PlotType {
 	case ScatterPlot:
 		for i, line := range self.Data {
-			previousHeight := 0
-      			if i == 0 {
-        			previousHeight = int((line[i] / maxVal) * float64(drawArea.Dy()-1))
-      			} else {
-        			previousHeight = int((line[i-1] / maxVal) * float64(drawArea.Dy()-1))
-      			}
 			for j, val := range line {
 				height := int((val / maxVal) * float64(drawArea.Dy()-1))
 				canvas.SetPoint(
@@ -103,7 +97,7 @@ func (self *Plot) renderBraille(buf *Buffer, drawArea image.Rectangle, maxVal fl
 	case LineChart:
 		for i, line := range self.Data {
 			previousHeight := int((line[i] / maxVal) * float64(drawArea.Dy()-1))
-			for j, val := range line[1:] {
+			for j, val := range line[0:] {
 				height := int((val / maxVal) * float64(drawArea.Dy()-1))
 				canvas.SetLine(
 					image.Pt(

--- a/v3/widgets/plot.go
+++ b/v3/widgets/plot.go
@@ -96,7 +96,7 @@ func (self *Plot) renderBraille(buf *Buffer, drawArea image.Rectangle, maxVal fl
 		}
 	case LineChart:
 		for i, line := range self.Data {
-			previousHeight := int((line[1] / maxVal) * float64(drawArea.Dy()-1))
+			previousHeight := int((line[i] / maxVal) * float64(drawArea.Dy()-1))
 			for j, val := range line[1:] {
 				height := int((val / maxVal) * float64(drawArea.Dy()-1))
 				canvas.SetLine(

--- a/v3/widgets/plot.go
+++ b/v3/widgets/plot.go
@@ -83,6 +83,12 @@ func (self *Plot) renderBraille(buf *Buffer, drawArea image.Rectangle, maxVal fl
 	switch self.PlotType {
 	case ScatterPlot:
 		for i, line := range self.Data {
+			previousHeight := 0
+      			if i == 0 {
+        			previousHeight = int((line[i] / maxVal) * float64(drawArea.Dy()-1))
+      			} else {
+        			previousHeight = int((line[i-1] / maxVal) * float64(drawArea.Dy()-1))
+      			}
 			for j, val := range line {
 				height := int((val / maxVal) * float64(drawArea.Dy()-1))
 				canvas.SetPoint(


### PR DESCRIPTION
When a plot only has one data point, the code will make it go out of bounds (at index one). Test this by going to the example and setting

```go
p0.Data = [][]float64{[]float64{5}}
```
And it will crash.

Now it checks the `i`th element instead of one, and starts reading the data from `0` instead of `1`.