### PR TITLE
Various fixes to resolve barchart style inconsistencies

### DIFF
--- a/v3/widgets/barchart.go
+++ b/v3/widgets/barchart.go
@@ -71,7 +71,7 @@ func (self *BarChart) Draw(buf *Buffer) {
 		}
 
 		// draw number
-		numberXCoordinate := barXCoordinate + int((float64(self.BarWidth) / 2))
+		numberXCoordinate := barXCoordinate + self.calcNumberXPos(data)
 		if numberXCoordinate <= self.Inner.Max.X {
 			buf.SetString(
 				self.NumFormatter(data),
@@ -86,4 +86,22 @@ func (self *BarChart) Draw(buf *Buffer) {
 
 		barXCoordinate += (self.BarWidth + self.BarGap)
 	}
+}
+
+//
+// Compute bar text position based on character length.
+//
+func (self *BarChart) calcNumberXPos(data float64) int {
+	numFormatterData := self.NumFormatter(data)
+
+	numberCharsLen := len(numFormatterData)
+	barWidthCenter := int(float64(self.BarWidth / 2))
+
+	var numberXCharPos int = barWidthCenter - numberCharsLen + (numberCharsLen / 2)
+
+	if numberCharsLen > barWidthCenter {
+		numberXCharPos = numberCharsLen - barWidthCenter
+	}
+
+	return int(numberXCharPos)
 }

--- a/v3/widgets/barchart.go
+++ b/v3/widgets/barchart.go
@@ -52,7 +52,7 @@ func (self *BarChart) Draw(buf *Buffer) {
 		// draw bar
 		height := int((data / maxVal) * float64(self.Inner.Dy()-1))
 		for x := barXCoordinate; x < MinInt(barXCoordinate+self.BarWidth, self.Inner.Max.X); x++ {
-			for y := self.Inner.Max.Y - 2; y > (self.Inner.Max.Y-2)-height; y-- {
+			for y := self.Inner.Max.Y - 2; y >= (self.Inner.Max.Y-2)-height; y-- {
 				c := NewCell(' ', NewStyle(ColorClear, SelectColor(self.BarColors, i)))
 				buf.SetCell(c, image.Pt(x, y))
 			}


### PR DESCRIPTION
This PR contains a couple changes to resolve UI inconsistencies I found when using this library.  The overall goal is to have these items fixed upstream so I don't have to include a modified version of the `barchart.go` file in [my project](https://github.com/nuxy/go-crypto-market-ui/blob/master/lib/widgets/holdings.go) source.

### Proposed changes

**Commit 1**
The percent text value _always starts_ from the bar center position.  

While this looks great when working with one character `Data` values (as pictured in the [termui example](https://raw.githubusercontent.com/nuxy/termui/master/_assets/demo.gif)) it looks awkward when dealing with long values since items greater than `BarWidth / 2` end up bleeding into the next bar.  The position should be calculated based on the character length and `BarWidth` size available.

**Commit 2**
The bar is not completely rendered when `Data` values `< 2%` exist.  I'm not sure this is intentional but the chart should maintain consistent sizing in regard to the bar width even if the value is `1%` or less.

### Before

![Before](https://user-images.githubusercontent.com/1234102/101308364-8c4cdb00-37fe-11eb-9ef4-f32dd993a821.png)

### After

![After](https://user-images.githubusercontent.com/1234102/101308383-9373e900-37fe-11eb-908c-c3cb5df4e465.png)