### PR TITLE
Do not panic when scrolling an empty list

### DIFF
--- a/widgets/list.go
+++ b/widgets/list.go
@@ -96,6 +96,9 @@ func (self *List) ScrollAmount(amount int) {
 	} else {
 		self.SelectedRow += amount
 	}
+	if self.SelectedRow < 0 {
+		self.SelectedRow = 0
+	}
 }
 
 func (self *List) ScrollUp() {
@@ -133,4 +136,7 @@ func (self *List) ScrollTop() {
 
 func (self *List) ScrollBottom() {
 	self.SelectedRow = len(self.Rows) - 1
+	if self.SelectedRow < 0 {
+		self.SelectedRow = 0
+	}
 }

--- a/widgets/list_test.go
+++ b/widgets/list_test.go
@@ -1,0 +1,19 @@
+package widgets_test
+
+import (
+	"image"
+	"testing"
+
+	"github.com/gizak/termui/v3"
+	"github.com/gizak/termui/v3/widgets"
+)
+
+func TestEmptyListPageChange(t *testing.T) {
+	l := widgets.NewList()
+	l.SetRect(0, 0, 10, 10)
+	buff := termui.NewBuffer(image.Rect(0, 0, 10, 10))
+	l.ScrollDown()
+	l.Draw(buff)
+	l.ScrollBottom()
+	l.Draw(buff)
+}


### PR DESCRIPTION
Fixes the negative index when scrolling down an empty list. Added Unittest which fails without the fix