### PR TITLE
Fix style parser to handle [ or ] in text without style

### DIFF
--- a/style_parser.go
+++ b/style_parser.go
@@ -89,6 +89,12 @@ func processToken(token, previous string) (string, string) {
 
 func PrepareStyles(s string) []PreparedStyle {
 	items := []PreparedStyle{}
+	tokens := strings.Split(s, "](")
+	if len(tokens) == 1 {
+		// easy case, not styled string
+		ps := PreparedStyle{s, ""}
+		return []PreparedStyle{ps}
+	}
 	return items
 }
 

--- a/style_parser.go
+++ b/style_parser.go
@@ -5,6 +5,7 @@
 package termui
 
 import (
+	"fmt"
 	"strings"
 )
 
@@ -70,41 +71,54 @@ func readStyle(runes []rune, defaultStyle Style) Style {
 	return style
 }
 
-func lookLeftForBracket(s string) (string, string) {
-	index := strings.LastIndex(s, "[")
-	return s[0:index], s[index+1:]
+func lookLeftForBracket(s string) int {
+	return strings.LastIndex(s, "[")
 }
 
-func lookRightForEndStyle(s string) (string, string) {
-	index := strings.Index(s, ")")
-	return s[0:index], s[index+1:]
+func lookRightForEndStyle(s string) int {
+	return strings.Index(s, ")")
 }
 
 func BreakByStyles(s string) []string {
+	fmt.Println(s)
 	tokens := strings.Split(s, "](")
 	if len(tokens) == 1 {
 		return tokens
 	}
 
 	buff := []string{}
-	styleString := ""
-	remainder := tokens[0]
-	i := 1
-	for {
-		prefix, item := lookLeftForBracket(remainder)
-		styleString, remainder = lookRightForEndStyle(tokens[i])
-		i++
-		buff = append(buff, prefix)
-		buff = append(buff, item)
-		buff = append(buff, styleString)
-		if !strings.Contains(remainder, "[") {
-			buff = append(buff, remainder)
-			break
+
+	// test [blue](fg:blue,mod:bold) and [red](fg:red) and maybe even [foo](bg:red)!
+	for i, token := range tokens {
+		if i%2 == 0 {
+			index := lookLeftForBracket(token)
+			fmt.Println(i, "even", len(token), index)
+		} else {
+			index := lookRightForEndStyle(token)
+			fmt.Println(i, "odd", len(token), index)
 		}
-		if i > len(tokens)-1 {
-			break
-		}
+		buff = append(buff, token)
 	}
+
+	/*
+		styleString := ""
+		remainder := tokens[0]
+		i := 1
+		for {
+			prefix, item := lookLeftForBracket(remainder)
+			styleString, remainder = lookRightForEndStyle(tokens[i])
+			i++
+			buff = append(buff, prefix)
+			buff = append(buff, item)
+			buff = append(buff, styleString)
+			if !strings.Contains(remainder, "*") {
+				buff = append(buff, remainder)
+				break
+			}
+			if i > len(tokens)-1 {
+				break
+			}
+		}*/
 
 	return buff
 }

--- a/style_parser.go
+++ b/style_parser.go
@@ -105,6 +105,18 @@ func findStartEndOfStyle(pos int, runes []rune) StyleBlock {
 	return sb
 }
 
+func BreakBlocksIntoStrings(s string) {
+	blocks := FindStyleBlocks(s)
+	fmt.Println(blocks)
+	//[{5 28} {34 46} {63 75}]
+	for _, b := range blocks {
+	}
+	s[0:4]
+	s[29:33]
+	s[47:62]
+	s[76:77]
+}
+
 func FindStyleBlocks(s string) []StyleBlock {
 	items := []StyleBlock{}
 	runes := []rune(s)

--- a/style_parser.go
+++ b/style_parser.go
@@ -86,24 +86,31 @@ type StyleStringPosition struct {
 }
 
 func BreakByStyles(s string) []string {
+	return []string{}
+}
+
+func FindStylePositions(s string) []int {
 	fmt.Println(s)
 	index := strings.Index(s, "](")
 	if index == -1 {
-		return []string{s}
+		return []int{}
 	}
 
-	buff := []string{}
+	buff := []int{}
 
 	toProcess := s
+	offset := 0
 	for {
-		fmt.Println(index)
+		buff = append(buff, index+offset)
 		toProcess = toProcess[index+1:]
-		fmt.Println(toProcess)
+		offset += index + 1
 		index = strings.Index(toProcess, "](")
 		if index == -1 {
 			break
 		}
 	}
+
+	return buff
 
 	// test [blue](fg:blue,mod:bold) and [red](fg:red) and maybe even [foo](bg:red)!
 

--- a/style_parser.go
+++ b/style_parser.go
@@ -70,11 +70,30 @@ func readStyle(runes []rune, defaultStyle Style) Style {
 	return style
 }
 
+func processToken(token string) {
+}
+
 // ParseStyles parses a string for embedded Styles and returns []Cell with the correct styling.
 // Uses defaultStyle for any text without an embedded style.
 // Syntax is of the form [text](fg:<color>,mod:<attribute>,bg:<color>).
 // Ordering does not matter. All fields are optional.
 func ParseStyles(s string, defaultStyle Style) []Cell {
+	//test [blue](fg:blue,bg:white,mod:bold)
+	cells := []Cell{}
+
+	tokens := strings.Split(s, "](")
+	if len(tokens) == 1 {
+		// easy case, not styled string
+		return cells
+	}
+	for i := len(tokens) - 1; i > 0; i-- {
+		processToken(tokens[i])
+	}
+
+	return cells
+}
+
+func ParseStyles2(s string, defaultStyle Style) []Cell {
 	cells := []Cell{}
 	runes := []rune(s)
 	state := parserStateDefault

--- a/style_parser.go
+++ b/style_parser.go
@@ -151,10 +151,13 @@ func ParseStyles(s string, defaultStyle Style) []Cell {
 	}
 
 	//test  blue fg:blue,bg:white,mod:bold  and  red fg:red  and maybe even  foo bg:red !
+	style := defaultStyle
 	for i := len(items) - 1; i > -1; i-- {
 		if containsColorOrMod(items[i]) {
+			style = readStyle([]rune(items[i]), defaultStyle)
 		} else {
-			fmt.Println(items[i])
+			cells = append(cells, RunesToStyledCells([]rune(items[i]), style)...)
+			style = defaultStyle
 		}
 	}
 

--- a/style_parser.go
+++ b/style_parser.go
@@ -84,8 +84,36 @@ type StyleBlock struct {
 	End   int
 }
 
+func findStartEndOfStyle(pos int, runes []rune) StyleBlock {
+	current := pos
+	sb := StyleBlock{0, 0}
+	for {
+		current--
+		if runes[current] == tokenBeginStyledText {
+			sb.Start = current
+			break
+		}
+	}
+	current = pos
+	for {
+		current++
+		if runes[current] == tokenEndStyle {
+			sb.End = current
+			break
+		}
+	}
+	return sb
+}
+
 func FindStyleBlocks(s string) []StyleBlock {
 	items := []StyleBlock{}
+	runes := []rune(s)
+
+	positions := FindStylePositions(s)
+	for _, pos := range positions {
+		sb := findStartEndOfStyle(pos, runes)
+		items = append(items, sb)
+	}
 	return items
 }
 

--- a/style_parser.go
+++ b/style_parser.go
@@ -5,7 +5,6 @@
 package termui
 
 import (
-	"fmt"
 	"strings"
 )
 
@@ -71,17 +70,6 @@ func readStyle(runes []rune, defaultStyle Style) Style {
 	return style
 }
 
-func processToken(token, previous string) (string, string) {
-	fmt.Println("1", token)
-	index := strings.Index(token, ")")
-	if index == -1 {
-		return "", ""
-	}
-	styleString := token[0:index]
-	restOfString := token[index:]
-	return styleString, restOfString
-}
-
 func lookLeftForBracket(s string) (string, string) {
 	index := strings.LastIndex(s, "[")
 	return s[0:index], s[index+1:]
@@ -113,6 +101,9 @@ func BreakByStyles(s string) []string {
 			buff = append(buff, remainder)
 			break
 		}
+		if i > len(tokens)-1 {
+			break
+		}
 	}
 
 	return buff
@@ -139,9 +130,7 @@ func containsColorOrMod(s string) bool {
 func ParseStyles(s string, defaultStyle Style) []Cell {
 	cells := []Cell{}
 
-	fmt.Println("11")
 	items := BreakByStyles(s)
-	fmt.Println("11", len(items))
 	if len(items) == 1 {
 		runes := []rune(s)
 		for _, _rune := range runes {
@@ -150,13 +139,12 @@ func ParseStyles(s string, defaultStyle Style) []Cell {
 		return cells
 	}
 
-	//test  blue fg:blue,bg:white,mod:bold  and  red fg:red  and maybe even  foo bg:red !
 	style := defaultStyle
 	for i := len(items) - 1; i > -1; i-- {
 		if containsColorOrMod(items[i]) {
 			style = readStyle([]rune(items[i]), defaultStyle)
 		} else {
-			cells = append(cells, RunesToStyledCells([]rune(items[i]), style)...)
+			cells = append(RunesToStyledCells([]rune(items[i]), style), cells...)
 			style = defaultStyle
 		}
 	}

--- a/style_parser.go
+++ b/style_parser.go
@@ -105,18 +105,25 @@ func findStartEndOfStyle(pos int, runes []rune) StyleBlock {
 	return sb
 }
 
-func BreakBlocksIntoStrings(s string) {
+func BreakBlocksIntoStrings(s string) []string {
+	buff := []string{}
 	blocks := FindStyleBlocks(s)
 	startEnd := len(s)
 	for i := len(blocks) - 1; i >= 0; i-- {
 		b := blocks[i]
-		foo := s[b.End+1 : startEnd]
-		fmt.Println("|" + foo + "|")
-		fmt.Println("|" + s[b.Start:b.End+1] + "|")
+		item := s[b.End+1 : startEnd]
+		if item != "" {
+			buff = append([]string{item}, buff...)
+		}
+		item = s[b.Start : b.End+1]
+		buff = append([]string{item}, buff...)
 		startEnd = b.Start
 	}
-	foo := s[0:startEnd]
-	fmt.Println("|" + foo + "|")
+	item := s[0:startEnd]
+	if item != "" {
+		buff = append([]string{item}, buff...)
+	}
+	return buff
 }
 
 func FindStyleBlocks(s string) []StyleBlock {

--- a/style_parser.go
+++ b/style_parser.go
@@ -87,6 +87,44 @@ func processToken(token, previous string) (string, string) {
 	return styleString, restOfString
 }
 
+func lookLeftForBracket(s string) (string, string) {
+	index := strings.LastIndex(s, "[")
+	return s[0:index], s[index+1:]
+}
+
+func lookRightForEndStyle(s string) (string, string) {
+	index := strings.Index(s, ")")
+	return s[0:index], s[index+1:]
+}
+
+func BreakByStyles(s string) []string {
+	// "test [blue](fg:blue,bg:white,mod:bold) and [red](fg:red)"
+	tokens := strings.Split(s, "](")
+	if len(tokens) == 1 {
+		return tokens
+	}
+
+	styleString := ""
+	remainder := tokens[0]
+	i := 1
+	for {
+		prefix, item := lookLeftForBracket(remainder)
+		styleString, remainder = lookRightForEndStyle(tokens[i])
+		i++
+		fmt.Println(i, prefix)
+		fmt.Println(i, item)
+		fmt.Println(i, styleString)
+		fmt.Println(i, remainder)
+		if !strings.Contains(remainder, "[") {
+			break
+		}
+	}
+
+	buffer := []string{}
+
+	return buffer
+}
+
 func PrepareStyles(s string) []PreparedStyle {
 	items := []PreparedStyle{}
 	tokens := strings.Split(s, "](")
@@ -95,6 +133,8 @@ func PrepareStyles(s string) []PreparedStyle {
 		ps := PreparedStyle{s, ""}
 		return []PreparedStyle{ps}
 	}
+
+	fmt.Println(strings.Join(tokens, "|"))
 	return items
 }
 

--- a/style_parser.go
+++ b/style_parser.go
@@ -79,6 +79,12 @@ func lookRightForEndStyle(s string) int {
 	return strings.Index(s, ")")
 }
 
+type StyleStringPosition struct {
+	Start   int
+	End     int
+	IsStyle bool
+}
+
 func BreakByStyles(s string) []string {
 	fmt.Println(s)
 	tokens := strings.Split(s, "](")
@@ -86,19 +92,31 @@ func BreakByStyles(s string) []string {
 		return tokens
 	}
 
+	ssps := []StyleStringPosition{}
 	buff := []string{}
 
 	// test [blue](fg:blue,mod:bold) and [red](fg:red) and maybe even [foo](bg:red)!
+	offset := 0
 	for i, token := range tokens {
 		if i%2 == 0 {
 			index := lookLeftForBracket(token)
+			ssp := StyleStringPosition{offset, offset + index, false}
+			ssps = append(ssps, ssp)
+			ssp = StyleStringPosition{offset + index, offset + len(token), true}
+			ssps = append(ssps, ssp)
 			fmt.Println(i, "even", len(token), index)
 		} else {
 			index := lookRightForEndStyle(token)
+			ssp := StyleStringPosition{offset, offset + index, true}
+			ssps = append(ssps, ssp)
+			ssp = StyleStringPosition{offset + index, offset + len(token), false}
+			ssps = append(ssps, ssp)
 			fmt.Println(i, "odd", len(token), index)
 		}
+		offset += len(token) + 2
 		buff = append(buff, token)
 	}
+	fmt.Println(ssps)
 
 	/*
 		styleString := ""

--- a/style_parser.go
+++ b/style_parser.go
@@ -79,14 +79,14 @@ func lookRightForEndStyle(s string) int {
 	return strings.Index(s, ")")
 }
 
-type StyleStringPosition struct {
-	Start   int
-	End     int
-	IsStyle bool
+type StyleBlock struct {
+	Start int
+	End   int
 }
 
-func BreakByStyles(s string) []string {
-	return []string{}
+func FindStyleBlocks(s string) []StyleBlock {
+	items := []StyleBlock{}
+	return items
 }
 
 func FindStylePositions(s string) []int {

--- a/style_parser.go
+++ b/style_parser.go
@@ -5,6 +5,7 @@
 package termui
 
 import (
+	"fmt"
 	"strings"
 )
 
@@ -176,12 +177,16 @@ func containsStyle(s string) bool {
 	return false
 }
 
+// [text](style) will return text
 func extractTextFromBlock(item string) string {
-	return "hi"
+	index := strings.Index(item, string(tokenEndStyledText))
+	return item[1:index]
 }
 
+// [text](style) will return style
 func extractStyleFromBlock(item string) string {
-	return "fg:red"
+	index := strings.Index(item, string(tokenBeginStyle))
+	return item[index+1 : len(item)-1]
 }
 
 // ParseStyles parses a string for embedded Styles and returns []Cell with the correct styling.
@@ -200,10 +205,11 @@ func ParseStyles(s string, defaultStyle Style) []Cell {
 		if containsStyle(item) {
 			text := extractTextFromBlock(item)
 			styleText := extractStyleFromBlock(item)
+			fmt.Println("|" + text + "|" + styleText + "|")
 			style := readStyle([]rune(styleText), defaultStyle)
-			cells = append(RunesToStyledCells([]rune(text), style), cells...)
+			cells = append(cells, RunesToStyledCells([]rune(text), style)...)
 		} else {
-			cells = append(RunesToStyledCells([]rune(item), defaultStyle), cells...)
+			cells = append(cells, RunesToStyledCells([]rune(item), defaultStyle)...)
 		}
 	}
 	return cells

--- a/style_parser.go
+++ b/style_parser.go
@@ -87,72 +87,70 @@ type StyleStringPosition struct {
 
 func BreakByStyles(s string) []string {
 	fmt.Println(s)
-	tokens := strings.Split(s, "](")
-	if len(tokens) == 1 {
-		return tokens
+	index := strings.Index(s, "](")
+	if index == -1 {
+		return []string{s}
 	}
 
-	ssps := []StyleStringPosition{}
 	buff := []string{}
 
-	// test [blue](fg:blue,mod:bold) and [red](fg:red) and maybe even [foo](bg:red)!
-	offset := 0
-	for i, token := range tokens {
-		if i%2 == 0 {
-			index := lookLeftForBracket(token)
-			ssp := StyleStringPosition{offset, offset + index, false}
-			ssps = append(ssps, ssp)
-			ssp = StyleStringPosition{offset + index, offset + len(token), true}
-			ssps = append(ssps, ssp)
-			fmt.Println(i, "even", len(token), index)
-		} else {
-			index := lookRightForEndStyle(token)
-			ssp := StyleStringPosition{offset, offset + index, true}
-			ssps = append(ssps, ssp)
-			ssp = StyleStringPosition{offset + index, offset + len(token), false}
-			ssps = append(ssps, ssp)
-			fmt.Println(i, "odd", len(token), index)
+	toProcess := s
+	for {
+		fmt.Println(index)
+		toProcess = toProcess[index+1:]
+		fmt.Println(toProcess)
+		index = strings.Index(toProcess, "](")
+		if index == -1 {
+			break
 		}
-		offset += len(token) + 2
-		buff = append(buff, token)
 	}
-	fmt.Println(ssps)
+
+	// test [blue](fg:blue,mod:bold) and [red](fg:red) and maybe even [foo](bg:red)!
 
 	/*
-		styleString := ""
-		remainder := tokens[0]
-		i := 1
-		for {
-			prefix, item := lookLeftForBracket(remainder)
-			styleString, remainder = lookRightForEndStyle(tokens[i])
-			i++
-			buff = append(buff, prefix)
-			buff = append(buff, item)
-			buff = append(buff, styleString)
-			if !strings.Contains(remainder, "*") {
-				buff = append(buff, remainder)
-				break
+		offset := 0
+		for i, token := range tokens {
+			if i%2 == 0 {
+				index := lookLeftForBracket(token)
+				ssp := StyleStringPosition{offset, offset + index, false}
+				ssps = append(ssps, ssp)
+				ssp = StyleStringPosition{offset + index, offset + len(token), true}
+				ssps = append(ssps, ssp)
+				fmt.Println(i, "even", len(token), index)
+			} else {
+				index := lookRightForEndStyle(token)
+				ssp := StyleStringPosition{offset, offset + index, true}
+				ssps = append(ssps, ssp)
+				ssp = StyleStringPosition{offset + index, offset + len(token), false}
+				ssps = append(ssps, ssp)
+				fmt.Println(i, "odd", len(token), index)
 			}
-			if i > len(tokens)-1 {
-				break
-			}
-		}*/
+			offset += len(token) + 2
+			buff = append(buff, token)
+		}
+		fmt.Println(ssps)
+
+
+			styleString := ""
+			remainder := tokens[0]
+			i := 1
+			for {
+				prefix, item := lookLeftForBracket(remainder)
+				styleString, remainder = lookRightForEndStyle(tokens[i])
+				i++
+				buff = append(buff, prefix)
+				buff = append(buff, item)
+				buff = append(buff, styleString)
+				if !strings.Contains(remainder, "*") {
+					buff = append(buff, remainder)
+					break
+				}
+				if i > len(tokens)-1 {
+					break
+				}
+			}*/
 
 	return buff
-}
-
-func containsColorOrMod(s string) bool {
-	if strings.Contains(s, "fg:") {
-		return true
-	}
-	if strings.Contains(s, "bg:") {
-		return true
-	}
-	if strings.Contains(s, "mod:") {
-		return true
-	}
-
-	return false
 }
 
 // ParseStyles parses a string for embedded Styles and returns []Cell with the correct styling.
@@ -162,25 +160,26 @@ func containsColorOrMod(s string) bool {
 func ParseStyles(s string, defaultStyle Style) []Cell {
 	cells := []Cell{}
 
-	items := BreakByStyles(s)
-	if len(items) == 1 {
-		runes := []rune(s)
-		for _, _rune := range runes {
-			cells = append(cells, Cell{_rune, defaultStyle})
+	/*
+		items := BreakByStyles(s)
+		if len(items) == 1 {
+			runes := []rune(s)
+			for _, _rune := range runes {
+				cells = append(cells, Cell{_rune, defaultStyle})
+			}
+			return cells
 		}
-		return cells
-	}
 
-	style := defaultStyle
-	for i := len(items) - 1; i > -1; i-- {
-		if containsColorOrMod(items[i]) {
-			style = readStyle([]rune(items[i]), defaultStyle)
-		} else {
-			cells = append(RunesToStyledCells([]rune(items[i]), style), cells...)
-			style = defaultStyle
+		style := defaultStyle
+		for i := len(items) - 1; i > -1; i-- {
+			if containsColorOrMod(items[i]) {
+				style = readStyle([]rune(items[i]), defaultStyle)
+			} else {
+				cells = append(RunesToStyledCells([]rune(items[i]), style), cells...)
+				style = defaultStyle
+			}
 		}
-	}
-
+	*/
 	return cells
 }
 

--- a/style_parser.go
+++ b/style_parser.go
@@ -70,7 +70,13 @@ func readStyle(runes []rune, defaultStyle Style) Style {
 	return style
 }
 
-func processToken(token string) {
+func processToken(token string) string {
+	index := strings.Index(token, ")")
+	if index == -1 {
+		return ""
+	}
+	styleString := token[0:index]
+	return styleString
 }
 
 // ParseStyles parses a string for embedded Styles and returns []Cell with the correct styling.
@@ -86,8 +92,10 @@ func ParseStyles(s string, defaultStyle Style) []Cell {
 		// easy case, not styled string
 		return cells
 	}
-	for i := len(tokens) - 1; i > 0; i-- {
-		processToken(tokens[i])
+
+	styleString := ""
+	for i := len(tokens) - 1; i >= 0; i-- {
+		styleString = processToken(tokens[i])
 	}
 
 	return cells

--- a/style_parser.go
+++ b/style_parser.go
@@ -167,6 +167,12 @@ func findStylePositions(s string) []int {
 }
 
 func containsStyle(s string) bool {
+	if strings.HasPrefix(s, string(tokenBeginStyledText)) &&
+		strings.HasSuffix(s, string(tokenEndStyle)) &&
+		strings.Contains(s, string(tokenEndStyledText)) &&
+		strings.Contains(s, string(tokenBeginStyle)) {
+		return true
+	}
 	return false
 }
 

--- a/style_parser.go
+++ b/style_parser.go
@@ -5,6 +5,7 @@
 package termui
 
 import (
+	"fmt"
 	"strings"
 )
 
@@ -24,6 +25,11 @@ const (
 )
 
 type parserState uint
+
+type PreparedStyle struct {
+	Text  string
+	Style string
+}
 
 const (
 	parserStateDefault parserState = iota
@@ -70,13 +76,20 @@ func readStyle(runes []rune, defaultStyle Style) Style {
 	return style
 }
 
-func processToken(token string) string {
+func processToken(token, previous string) (string, string) {
+	fmt.Println("1", token)
 	index := strings.Index(token, ")")
 	if index == -1 {
-		return ""
+		return "", ""
 	}
 	styleString := token[0:index]
-	return styleString
+	restOfString := token[index:]
+	return styleString, restOfString
+}
+
+func PrepareStyles(s string) []PreparedStyle {
+	items := []PreparedStyle{}
+	return items
 }
 
 // ParseStyles parses a string for embedded Styles and returns []Cell with the correct styling.
@@ -93,10 +106,16 @@ func ParseStyles(s string, defaultStyle Style) []Cell {
 		return cells
 	}
 
-	styleString := ""
-	for i := len(tokens) - 1; i >= 0; i-- {
-		styleString = processToken(tokens[i])
+	styleString, rest := processToken(tokens[len(tokens)-1], "")
+	fmt.Println("2", styleString, rest)
+	for i := len(tokens) - 2; i >= 0; i-- {
+		styleString, rest = processToken(tokens[i], styleString)
+		fmt.Println("3", styleString, rest)
 	}
+
+	//1 fg:red)
+	//1 fg:blue,bg:white,mod:bold) and [red
+	//1 test [blue
 
 	return cells
 }

--- a/style_parser.go
+++ b/style_parser.go
@@ -5,7 +5,6 @@
 package termui
 
 import (
-	"fmt"
 	"strings"
 )
 
@@ -205,7 +204,6 @@ func ParseStyles(s string, defaultStyle Style) []Cell {
 		if containsStyle(item) {
 			text := extractTextFromBlock(item)
 			styleText := extractStyleFromBlock(item)
-			fmt.Println("|" + text + "|" + styleText + "|")
 			style := readStyle([]rune(styleText), defaultStyle)
 			cells = append(cells, RunesToStyledCells([]rune(text), style)...)
 		} else {

--- a/style_parser.go
+++ b/style_parser.go
@@ -71,14 +71,6 @@ func readStyle(runes []rune, defaultStyle Style) Style {
 	return style
 }
 
-func lookLeftForBracket(s string) int {
-	return strings.LastIndex(s, "[")
-}
-
-func lookRightForEndStyle(s string) int {
-	return strings.Index(s, ")")
-}
-
 type StyleBlock struct {
 	Start int
 	End   int
@@ -108,6 +100,9 @@ func findStartEndOfStyle(pos int, runes []rune) StyleBlock {
 func BreakBlocksIntoStrings(s string) []string {
 	buff := []string{}
 	blocks := FindStyleBlocks(s)
+	if len(blocks) == 0 {
+		return buff
+	}
 	startEnd := len(s)
 	for i := len(blocks) - 1; i >= 0; i-- {
 		b := blocks[i]
@@ -160,53 +155,18 @@ func FindStylePositions(s string) []int {
 	}
 
 	return buff
+}
 
-	// test [blue](fg:blue,mod:bold) and [red](fg:red) and maybe even [foo](bg:red)!
+func containsStyle(s string) bool {
+	return false
+}
 
-	/*
-		offset := 0
-		for i, token := range tokens {
-			if i%2 == 0 {
-				index := lookLeftForBracket(token)
-				ssp := StyleStringPosition{offset, offset + index, false}
-				ssps = append(ssps, ssp)
-				ssp = StyleStringPosition{offset + index, offset + len(token), true}
-				ssps = append(ssps, ssp)
-				fmt.Println(i, "even", len(token), index)
-			} else {
-				index := lookRightForEndStyle(token)
-				ssp := StyleStringPosition{offset, offset + index, true}
-				ssps = append(ssps, ssp)
-				ssp = StyleStringPosition{offset + index, offset + len(token), false}
-				ssps = append(ssps, ssp)
-				fmt.Println(i, "odd", len(token), index)
-			}
-			offset += len(token) + 2
-			buff = append(buff, token)
-		}
-		fmt.Println(ssps)
+func extractTextFromBlock(item string) string {
+	return "hi"
+}
 
-
-			styleString := ""
-			remainder := tokens[0]
-			i := 1
-			for {
-				prefix, item := lookLeftForBracket(remainder)
-				styleString, remainder = lookRightForEndStyle(tokens[i])
-				i++
-				buff = append(buff, prefix)
-				buff = append(buff, item)
-				buff = append(buff, styleString)
-				if !strings.Contains(remainder, "*") {
-					buff = append(buff, remainder)
-					break
-				}
-				if i > len(tokens)-1 {
-					break
-				}
-			}*/
-
-	return buff
+func extractStyleFromBlock(item string) string {
+	return "fg:red"
 }
 
 // ParseStyles parses a string for embedded Styles and returns []Cell with the correct styling.
@@ -216,26 +176,21 @@ func FindStylePositions(s string) []int {
 func ParseStyles(s string, defaultStyle Style) []Cell {
 	cells := []Cell{}
 
-	/*
-		items := BreakByStyles(s)
-		if len(items) == 1 {
-			runes := []rune(s)
-			for _, _rune := range runes {
-				cells = append(cells, Cell{_rune, defaultStyle})
-			}
-			return cells
-		}
+	items := BreakBlocksIntoStrings(s)
+	if len(items) == 0 {
+		return RunesToStyledCells([]rune(s), defaultStyle)
+	}
 
-		style := defaultStyle
-		for i := len(items) - 1; i > -1; i-- {
-			if containsColorOrMod(items[i]) {
-				style = readStyle([]rune(items[i]), defaultStyle)
-			} else {
-				cells = append(RunesToStyledCells([]rune(items[i]), style), cells...)
-				style = defaultStyle
-			}
+	for _, item := range items {
+		if containsStyle(item) {
+			text := extractTextFromBlock(item)
+			styleText := extractStyleFromBlock(item)
+			style := readStyle([]rune(styleText), defaultStyle)
+			cells = append(RunesToStyledCells([]rune(text), style), cells...)
+		} else {
+			cells = append(RunesToStyledCells([]rune(item), defaultStyle), cells...)
 		}
-	*/
+	}
 	return cells
 }
 

--- a/style_parser.go
+++ b/style_parser.go
@@ -107,14 +107,16 @@ func findStartEndOfStyle(pos int, runes []rune) StyleBlock {
 
 func BreakBlocksIntoStrings(s string) {
 	blocks := FindStyleBlocks(s)
-	fmt.Println(blocks)
-	//[{5 28} {34 46} {63 75}]
-	for _, b := range blocks {
+	startEnd := len(s)
+	for i := len(blocks) - 1; i >= 0; i-- {
+		b := blocks[i]
+		foo := s[b.End+1 : startEnd]
+		fmt.Println("|" + foo + "|")
+		fmt.Println("|" + s[b.Start:b.End+1] + "|")
+		startEnd = b.Start
 	}
-	s[0:4]
-	s[29:33]
-	s[47:62]
-	s[76:77]
+	foo := s[0:startEnd]
+	fmt.Println("|" + foo + "|")
 }
 
 func FindStyleBlocks(s string) []StyleBlock {

--- a/style_parser_test.go
+++ b/style_parser_test.go
@@ -6,8 +6,9 @@ import (
 )
 
 func TestParseStyles(t *testing.T) {
-	cells := ParseStyles("test [blue](fg:blue,bg:white,mod:bold)", NewStyle(ColorWhite))
-	if len(cells) != 9 {
+	cells := ParseStyles("test nothing", NewStyle(ColorWhite))
+	cells = ParseStyles("test [blue](fg:blue,bg:white,mod:bold) and [red](fg:red)", NewStyle(ColorWhite))
+	if len(cells) != 17 {
 		t.Fatal("wrong length", len(cells))
 	}
 	for i := 0; i < 5; i++ {
@@ -21,7 +22,7 @@ func TestParseStyles(t *testing.T) {
 			t.Fatal("wrong mod", cells[i])
 		}
 	}
-	for i := 5; i < len(cells); i++ {
+	for i := 5; i < 9; i++ {
 		if cells[i].Style.Fg != ColorBlue {
 			t.Fatal("wrong fg color", cells[i])
 		}
@@ -34,7 +35,7 @@ func TestParseStyles(t *testing.T) {
 	}
 
 	text := textFromCells(cells)
-	if text != "test blue" {
+	if text != "test blue and red" {
 		t.Fatal("wrong text", text)
 	}
 

--- a/style_parser_test.go
+++ b/style_parser_test.go
@@ -7,12 +7,12 @@ import (
 )
 
 func TestBreakBlocksIntoStrings(t *testing.T) {
-	items := BreakBlocksIntoStrings("test [blue](fg:blue,mod:bold) and [red](fg:red) and maybe even [foo](bg:red)!")
+	items := breakBlocksIntoStrings("test [blue](fg:blue,mod:bold) and [red](fg:red) and maybe even [foo](bg:red)!")
 	fmt.Println(strings.Join(items, ""))
 }
 
 func TestFindStylePositions(t *testing.T) {
-	items := FindStylePositions("test [blue](fg:blue,mod:bold) and [red](fg:red) and maybe even [foo](bg:red)!")
+	items := findStylePositions("test [blue](fg:blue,mod:bold) and [red](fg:red) and maybe even [foo](bg:red)!")
 	if len(items) != 3 {
 		t.Fatal("wrong length", len(items))
 	}
@@ -28,7 +28,7 @@ func TestFindStylePositions(t *testing.T) {
 }
 
 func TestFindStyleBlocks(t *testing.T) {
-	items := FindStyleBlocks("test [blue](fg:blue,mod:bold) and [red](fg:red) and maybe even [foo](bg:red)!")
+	items := findStyleBlocks("test [blue](fg:blue,mod:bold) and [red](fg:red) and maybe even [foo](bg:red)!")
 	if len(items) != 3 {
 		t.Fatal("wrong length", len(items))
 	}

--- a/style_parser_test.go
+++ b/style_parser_test.go
@@ -1,14 +1,15 @@
 package termui
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 )
 
 func TestBreakBlocksIntoStrings(t *testing.T) {
 	items := breakBlocksIntoStrings("test [blue](fg:blue,mod:bold) and [red](fg:red) and maybe even [foo](bg:red)!")
-	fmt.Println(strings.Join(items, ""))
+	if len(items) != 7 {
+		t.Fatal("wrong length", len(items))
+	}
 }
 
 func TestFindStylePositions(t *testing.T) {

--- a/style_parser_test.go
+++ b/style_parser_test.go
@@ -1,0 +1,16 @@
+package termui
+
+import (
+	"testing"
+)
+
+func TestParseStyles(t *testing.T) {
+	cells := ParseStyles("test [blue](fg:blue)", NewStyle(ColorWhite))
+	if cells[0].Style.Fg != 7 {
+		t.Fatal("normal text fg is wrong")
+	}
+	if cells[5].Style.Fg != 4 {
+		t.Fatal("blue text fg is wrong")
+	}
+
+}

--- a/style_parser_test.go
+++ b/style_parser_test.go
@@ -1,12 +1,18 @@
 package termui
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
 
-func TestBreakByStyles(t *testing.T) {
-	items := BreakByStyles("test [blue](fg:blue,bg:white,mod:bold) and [red](fg:red) and maybe even [foo](bg:red)!")
+func TestBreakByStylesComplex(t *testing.T) {
+	items := BreakByStyles("test [blue](fg:blue,mod:bold) and [red](fg:red) and maybe even [foo](bg:red)!")
+	// "test [blue](fg:blue,mod:bold) and [red](fg:red) and maybe even [foo](bg:red)!"
+	//  01234567890123456789012345678
+	//   0- 4  normal
+	//   5-28  style
+	//  29-
 	if len(items) != 10 {
 		t.Fatal("wrong length", len(items))
 	}
@@ -14,6 +20,13 @@ func TestBreakByStyles(t *testing.T) {
 	if text != "test  blue fg:blue,bg:white,mod:bold  and  red fg:red  and maybe even  foo bg:red !" {
 		t.Fatal("wrong text", text)
 	}
+}
+func TestBreakByStylesSimpler(t *testing.T) {
+	items := BreakByStyles("[blue](fg:blue) [1]")
+	// [blue](fg:blue) [1]
+	// 012345678901234
+	// 0-14, rest
+	fmt.Println(items, len(items))
 }
 
 func TestParseStyles(t *testing.T) {

--- a/style_parser_test.go
+++ b/style_parser_test.go
@@ -6,13 +6,15 @@ import (
 	"testing"
 )
 
+func TestFindStylePositions(t *testing.T) {
+	items := FindStylePositions("test [blue](fg:blue,mod:bold) and [red](fg:red) and maybe even [foo](bg:red)!")
+	if len(items) != 3 {
+		t.Fatal("wrong length", len(items))
+	}
+}
+
 func TestBreakByStylesComplex(t *testing.T) {
 	items := BreakByStyles("test [blue](fg:blue,mod:bold) and [red](fg:red) and maybe even [foo](bg:red)!")
-	// "test [blue](fg:blue,mod:bold) and [red](fg:red) and maybe even [foo](bg:red)!"
-	//  01234567890123456789012345678
-	//   0- 4  normal
-	//   5-28  style
-	//  29-
 	if len(items) != 10 {
 		t.Fatal("wrong length", len(items))
 	}

--- a/style_parser_test.go
+++ b/style_parser_test.go
@@ -1,9 +1,17 @@
 package termui
 
 import (
-	"strings"
 	"testing"
 )
+
+func TestBreakByStyles(t *testing.T) {
+	items := BreakByStyles("test [blue](fg:blue,bg:white,mod:bold) and [red](fg:red) and maybe even [foo](more)!")
+	//test [blue|fg:blue,bg:white,mod:bold) and [red|fg:red)
+	//test|blue|fg:blue,bg:white,mod:bold| and |red|fg:red
+	if len(items) != 6 {
+		t.Fatal("wrong length", len(items))
+	}
+}
 
 func TestPrepareStyles(t *testing.T) {
 	items := PrepareStyles("test no style")
@@ -11,6 +19,7 @@ func TestPrepareStyles(t *testing.T) {
 		t.Fatal("wrong length", len(items))
 	}
 	items = PrepareStyles("test [blue](fg:blue,bg:white,mod:bold) and [red](fg:red)")
+	//test [blue|fg:blue,bg:white,mod:bold) and [red|fg:red)
 	if len(items) != 4 {
 		t.Fatal("wrong length", len(items))
 	}
@@ -40,6 +49,7 @@ func TestPrepareStyles(t *testing.T) {
 	}
 }
 
+/*
 func TestParseStyles(t *testing.T) {
 	cells := ParseStyles("test nothing", NewStyle(ColorWhite))
 	cells = ParseStyles("test [blue](fg:blue,bg:white,mod:bold) and [red](fg:red)", NewStyle(ColorWhite))
@@ -100,4 +110,4 @@ func textFromCells(cells []Cell) string {
 		buff = append(buff, string(cell.Rune))
 	}
 	return strings.Join(buff, "")
-}
+}*/

--- a/style_parser_test.go
+++ b/style_parser_test.go
@@ -1,7 +1,6 @@
 package termui
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 )
@@ -22,22 +21,20 @@ func TestFindStylePositions(t *testing.T) {
 	}
 }
 
-func TestBreakByStylesComplex(t *testing.T) {
-	items := BreakByStyles("test [blue](fg:blue,mod:bold) and [red](fg:red) and maybe even [foo](bg:red)!")
-	if len(items) != 10 {
+func TestFindStyleBlocks(t *testing.T) {
+	items := FindStyleBlocks("test [blue](fg:blue,mod:bold) and [red](fg:red) and maybe even [foo](bg:red)!")
+	if len(items) != 3 {
 		t.Fatal("wrong length", len(items))
 	}
-	text := strings.Join(items, " ")
-	if text != "test  blue fg:blue,bg:white,mod:bold  and  red fg:red  and maybe even  foo bg:red !" {
-		t.Fatal("wrong text", text)
+	if items[0].Start != 5 && items[0].End != 28 {
+		t.Fatal("wrong index", items[0])
 	}
-}
-func TestBreakByStylesSimpler(t *testing.T) {
-	items := BreakByStyles("[blue](fg:blue) [1]")
-	// [blue](fg:blue) [1]
-	// 012345678901234
-	// 0-14, rest
-	fmt.Println(items, len(items))
+	if items[1].Start != 34 && items[1].End != 46 {
+		t.Fatal("wrong index", items[1])
+	}
+	if items[2].Start != 63 && items[2].End != 75 {
+		t.Fatal("wrong index", items[2])
+	}
 }
 
 func TestParseStyles(t *testing.T) {

--- a/style_parser_test.go
+++ b/style_parser_test.go
@@ -1,6 +1,7 @@
 package termui
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -19,6 +20,9 @@ func TestBreakByStyles(t *testing.T) {
 func TestParseStyles(t *testing.T) {
 	cells := ParseStyles("test nothing", NewStyle(ColorWhite))
 	cells = ParseStyles("test [blue](fg:blue,bg:white,mod:bold) and [red](fg:red)", NewStyle(ColorWhite))
+	fmt.Println(cells)
+	text2 := textFromCells(cells)
+	fmt.Println(text2)
 	if len(cells) != 17 {
 		t.Fatal("wrong length", len(cells))
 	}

--- a/style_parser_test.go
+++ b/style_parser_test.go
@@ -5,6 +5,10 @@ import (
 	"testing"
 )
 
+func TestBreakBlocksIntoStrings(t *testing.T) {
+	BreakBlocksIntoStrings("test [blue](fg:blue,mod:bold) and [red](fg:red) and maybe even [foo](bg:red)!")
+}
+
 func TestFindStylePositions(t *testing.T) {
 	items := FindStylePositions("test [blue](fg:blue,mod:bold) and [red](fg:red) and maybe even [foo](bg:red)!")
 	if len(items) != 3 {

--- a/style_parser_test.go
+++ b/style_parser_test.go
@@ -1,12 +1,14 @@
 package termui
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
 
 func TestBreakBlocksIntoStrings(t *testing.T) {
-	BreakBlocksIntoStrings("test [blue](fg:blue,mod:bold) and [red](fg:red) and maybe even [foo](bg:red)!")
+	items := BreakBlocksIntoStrings("test [blue](fg:blue,mod:bold) and [red](fg:red) and maybe even [foo](bg:red)!")
+	fmt.Println(strings.Join(items, ""))
 }
 
 func TestFindStylePositions(t *testing.T) {

--- a/style_parser_test.go
+++ b/style_parser_test.go
@@ -13,4 +13,8 @@ func TestParseStyles(t *testing.T) {
 		t.Fatal("blue text fg is wrong")
 	}
 
+	cells = ParseStyles("[hi]", NewStyle(ColorWhite))
+	if len(cells) != 4 {
+		t.Fatal("missing closing ]")
+	}
 }

--- a/style_parser_test.go
+++ b/style_parser_test.go
@@ -6,7 +6,33 @@ import (
 )
 
 func TestParseStyles(t *testing.T) {
-	cells := ParseStyles("test [blue](fg:blue)", NewStyle(ColorWhite))
+	cells := ParseStyles("test [blue](fg:blue,bg:white,mod:bold)", NewStyle(ColorWhite))
+	if len(cells) != 9 {
+		t.Fatal("wrong length", len(cells))
+	}
+	for i := 0; i < 5; i++ {
+		if cells[i].Style.Fg != ColorWhite {
+			t.Fatal("wrong fg color", cells[i])
+		}
+		if cells[i].Style.Bg != ColorClear {
+			t.Fatal("wrong bg color", cells[i])
+		}
+		if cells[i].Style.Modifier != ModifierClear {
+			t.Fatal("wrong mod", cells[i])
+		}
+	}
+	for i := 5; i < len(cells); i++ {
+		if cells[i].Style.Fg != ColorBlue {
+			t.Fatal("wrong fg color", cells[i])
+		}
+		if cells[i].Style.Bg != ColorWhite {
+			t.Fatal("wrong bg color", cells[i])
+		}
+		if cells[i].Style.Modifier != ModifierBold {
+			t.Fatal("wrong mod", cells[i])
+		}
+	}
+
 	text := textFromCells(cells)
 	if text != "test blue" {
 		t.Fatal("wrong text", text)

--- a/style_parser_test.go
+++ b/style_parser_test.go
@@ -1,6 +1,7 @@
 package termui
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -50,9 +51,12 @@ func TestParseStyles(t *testing.T) {
 	if len(cells) != 17 {
 		t.Fatal("wrong length", len(cells))
 	}
+	text := textFromCells(cells)
+	fmt.Println(text)
+	fmt.Println(cells)
 	for i := 0; i < 5; i++ {
 		if cells[i].Style.Fg != ColorWhite {
-			t.Fatal("wrong fg color", cells[i])
+			t.Fatal("wrong fg color", cells[i], i)
 		}
 		if cells[i].Style.Bg != ColorClear {
 			t.Fatal("wrong bg color", cells[i])
@@ -73,7 +77,7 @@ func TestParseStyles(t *testing.T) {
 		}
 	}
 
-	text := textFromCells(cells)
+	text = textFromCells(cells)
 	if text != "test blue and red" {
 		t.Fatal("wrong text", text)
 	}

--- a/style_parser_test.go
+++ b/style_parser_test.go
@@ -5,6 +5,37 @@ import (
 	"testing"
 )
 
+func TestPrepareStyles(t *testing.T) {
+	items := PrepareStyles("test [blue](fg:blue,bg:white,mod:bold) and [red](fg:red)")
+	if len(items) != 4 {
+		t.Fatal("wrong length", len(items))
+	}
+	if items[0].Text != "test " {
+		t.Fatal("wrong text", items[0].Text)
+	}
+	if items[0].Style != "" {
+		t.Fatal("wrong text", items[0].Style)
+	}
+	if items[1].Text != "blue" {
+		t.Fatal("wrong text", items[1].Text)
+	}
+	if items[1].Style != "fg:blue,bg:white,mod:bold" {
+		t.Fatal("wrong text", items[1].Style)
+	}
+	if items[2].Text != " and " {
+		t.Fatal("wrong text", items[2].Text)
+	}
+	if items[2].Style != "" {
+		t.Fatal("wrong text", items[2].Style)
+	}
+	if items[3].Text != "red" {
+		t.Fatal("wrong text", items[3].Text)
+	}
+	if items[3].Style != "fg:red" {
+		t.Fatal("wrong text", items[3].Style)
+	}
+}
+
 func TestParseStyles(t *testing.T) {
 	cells := ParseStyles("test nothing", NewStyle(ColorWhite))
 	cells = ParseStyles("test [blue](fg:blue,bg:white,mod:bold) and [red](fg:red)", NewStyle(ColorWhite))

--- a/style_parser_test.go
+++ b/style_parser_test.go
@@ -12,9 +12,9 @@ func TestParseStyles(t *testing.T) {
 		t.Fatal("wrong text", text)
 	}
 
-	cells = ParseStyles("[blue](fg:blue) [1] ", NewStyle(ColorWhite))
+	cells = ParseStyles("[blue](fg:blue) [1]", NewStyle(ColorWhite))
 	text = textFromCells(cells)
-	if text != "blue [1] hello" {
+	if text != "blue [1]" {
 		t.Fatal("wrong text", text)
 	}
 

--- a/style_parser_test.go
+++ b/style_parser_test.go
@@ -6,7 +6,11 @@ import (
 )
 
 func TestPrepareStyles(t *testing.T) {
-	items := PrepareStyles("test [blue](fg:blue,bg:white,mod:bold) and [red](fg:red)")
+	items := PrepareStyles("test no style")
+	if len(items) != 1 {
+		t.Fatal("wrong length", len(items))
+	}
+	items = PrepareStyles("test [blue](fg:blue,bg:white,mod:bold) and [red](fg:red)")
 	if len(items) != 4 {
 		t.Fatal("wrong length", len(items))
 	}

--- a/style_parser_test.go
+++ b/style_parser_test.go
@@ -1,55 +1,21 @@
 package termui
 
 import (
+	"strings"
 	"testing"
 )
 
 func TestBreakByStyles(t *testing.T) {
-	items := BreakByStyles("test [blue](fg:blue,bg:white,mod:bold) and [red](fg:red) and maybe even [foo](more)!")
-	//test [blue|fg:blue,bg:white,mod:bold) and [red|fg:red)
-	//test|blue|fg:blue,bg:white,mod:bold| and |red|fg:red
-	if len(items) != 6 {
+	items := BreakByStyles("test [blue](fg:blue,bg:white,mod:bold) and [red](fg:red) and maybe even [foo](bg:red)!")
+	if len(items) != 10 {
 		t.Fatal("wrong length", len(items))
+	}
+	text := strings.Join(items, " ")
+	if text != "test  blue fg:blue,bg:white,mod:bold  and  red fg:red  and maybe even  foo bg:red !" {
+		t.Fatal("wrong text", text)
 	}
 }
 
-func TestPrepareStyles(t *testing.T) {
-	items := PrepareStyles("test no style")
-	if len(items) != 1 {
-		t.Fatal("wrong length", len(items))
-	}
-	items = PrepareStyles("test [blue](fg:blue,bg:white,mod:bold) and [red](fg:red)")
-	//test [blue|fg:blue,bg:white,mod:bold) and [red|fg:red)
-	if len(items) != 4 {
-		t.Fatal("wrong length", len(items))
-	}
-	if items[0].Text != "test " {
-		t.Fatal("wrong text", items[0].Text)
-	}
-	if items[0].Style != "" {
-		t.Fatal("wrong text", items[0].Style)
-	}
-	if items[1].Text != "blue" {
-		t.Fatal("wrong text", items[1].Text)
-	}
-	if items[1].Style != "fg:blue,bg:white,mod:bold" {
-		t.Fatal("wrong text", items[1].Style)
-	}
-	if items[2].Text != " and " {
-		t.Fatal("wrong text", items[2].Text)
-	}
-	if items[2].Style != "" {
-		t.Fatal("wrong text", items[2].Style)
-	}
-	if items[3].Text != "red" {
-		t.Fatal("wrong text", items[3].Text)
-	}
-	if items[3].Style != "fg:red" {
-		t.Fatal("wrong text", items[3].Style)
-	}
-}
-
-/*
 func TestParseStyles(t *testing.T) {
 	cells := ParseStyles("test nothing", NewStyle(ColorWhite))
 	cells = ParseStyles("test [blue](fg:blue,bg:white,mod:bold) and [red](fg:red)", NewStyle(ColorWhite))
@@ -110,4 +76,4 @@ func textFromCells(cells []Cell) string {
 		buff = append(buff, string(cell.Rune))
 	}
 	return strings.Join(buff, "")
-}*/
+}

--- a/style_parser_test.go
+++ b/style_parser_test.go
@@ -1,7 +1,6 @@
 package termui
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 )
@@ -20,9 +19,6 @@ func TestBreakByStyles(t *testing.T) {
 func TestParseStyles(t *testing.T) {
 	cells := ParseStyles("test nothing", NewStyle(ColorWhite))
 	cells = ParseStyles("test [blue](fg:blue,bg:white,mod:bold) and [red](fg:red)", NewStyle(ColorWhite))
-	fmt.Println(cells)
-	text2 := textFromCells(cells)
-	fmt.Println(text2)
 	if len(cells) != 17 {
 		t.Fatal("wrong length", len(cells))
 	}

--- a/style_parser_test.go
+++ b/style_parser_test.go
@@ -1,20 +1,41 @@
 package termui
 
 import (
+	"strings"
 	"testing"
 )
 
 func TestParseStyles(t *testing.T) {
 	cells := ParseStyles("test [blue](fg:blue)", NewStyle(ColorWhite))
-	if cells[0].Style.Fg != 7 {
-		t.Fatal("normal text fg is wrong")
-	}
-	if cells[5].Style.Fg != 4 {
-		t.Fatal("blue text fg is wrong")
+	text := textFromCells(cells)
+	if text != "test blue" {
+		t.Fatal("wrong text", text)
 	}
 
-	cells = ParseStyles("[hi]", NewStyle(ColorWhite))
-	if len(cells) != 4 {
-		t.Fatal("missing closing ]")
+	cells = ParseStyles("[blue](fg:blue) [1] ", NewStyle(ColorWhite))
+	text = textFromCells(cells)
+	if text != "blue [1] hello" {
+		t.Fatal("wrong text", text)
 	}
+
+	cells = ParseStyles("[0]", NewStyle(ColorWhite))
+	text = textFromCells(cells)
+	if text != "[0]" {
+		t.Fatal("wrong text", text)
+	}
+
+	cells = ParseStyles("[", NewStyle(ColorWhite))
+	text = textFromCells(cells)
+	if text != "[" {
+		t.Fatal("wrong text", text)
+	}
+
+}
+
+func textFromCells(cells []Cell) string {
+	buff := []string{}
+	for _, cell := range cells {
+		buff = append(buff, string(cell.Rune))
+	}
+	return strings.Join(buff, "")
 }

--- a/style_parser_test.go
+++ b/style_parser_test.go
@@ -11,6 +11,15 @@ func TestFindStylePositions(t *testing.T) {
 	if len(items) != 3 {
 		t.Fatal("wrong length", len(items))
 	}
+	if items[0] != 10 {
+		t.Fatal("wrong index", items[0])
+	}
+	if items[1] != 38 {
+		t.Fatal("wrong index", items[1])
+	}
+	if items[2] != 67 {
+		t.Fatal("wrong index", items[2])
+	}
 }
 
 func TestBreakByStylesComplex(t *testing.T) {

--- a/style_parser_test.go
+++ b/style_parser_test.go
@@ -1,7 +1,6 @@
 package termui
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 )
@@ -51,9 +50,6 @@ func TestParseStyles(t *testing.T) {
 	if len(cells) != 17 {
 		t.Fatal("wrong length", len(cells))
 	}
-	text := textFromCells(cells)
-	fmt.Println(text)
-	fmt.Println(cells)
 	for i := 0; i < 5; i++ {
 		if cells[i].Style.Fg != ColorWhite {
 			t.Fatal("wrong fg color", cells[i], i)
@@ -77,7 +73,7 @@ func TestParseStyles(t *testing.T) {
 		}
 	}
 
-	text = textFromCells(cells)
+	text := textFromCells(cells)
 	if text != "test blue and red" {
 		t.Fatal("wrong text", text)
 	}


### PR DESCRIPTION
There is a problem with using [ or ] in text. Style Parser thinks you are going to supply a (style) block after and eats some of the chars:

https://github.com/gizak/termui/issues/311

This PR re-writes the logic to look for pairs or "](" and only processes style when needed and leaves normal [ or ] in text alone.