### PR TITLE
clone slices to loosen reference

### DIFF
--- a/style.go
+++ b/style.go
@@ -20,6 +20,14 @@ const (
 	ColorWhite   Color = 7
 )
 
+// Colors represents a slice of colors
+type Colors []Color
+
+// Clone the colors slice to not keep a reference
+func (c Colors) Clone() Colors {
+	return append(make([]Color, 0), c...)
+}
+
 type Modifier uint
 
 const (
@@ -35,6 +43,14 @@ type Style struct {
 	Fg       Color
 	Bg       Color
 	Modifier Modifier
+}
+
+// Styles represents a slice of styles
+type Styles []Style
+
+// Clone the styles slice to not keep a reference
+func (s Styles) Clone() Styles {
+	return append(make([]Style, 0), s...)
 }
 
 // StyleClear represents a default Style, with no colors or modifiers

--- a/theme.go
+++ b/theme.go
@@ -4,7 +4,7 @@
 
 package termui
 
-var StandardColors = []Color{
+var StandardColors = Colors{
 	ColorRed,
 	ColorGreen,
 	ColorYellow,
@@ -14,7 +14,7 @@ var StandardColors = []Color{
 	ColorWhite,
 }
 
-var StandardStyles = []Style{
+var StandardStyles = Styles{
 	NewStyle(ColorRed),
 	NewStyle(ColorGreen),
 	NewStyle(ColorYellow),
@@ -48,9 +48,9 @@ type BlockTheme struct {
 }
 
 type BarChartTheme struct {
-	Bars   []Color
-	Nums   []Style
-	Labels []Style
+	Bars   Colors
+	Nums   Styles
+	Labels Styles
 }
 
 type GaugeTheme struct {
@@ -59,7 +59,7 @@ type GaugeTheme struct {
 }
 
 type PlotTheme struct {
-	Lines []Color
+	Lines Colors
 	Axes  Color
 }
 
@@ -78,7 +78,7 @@ type ParagraphTheme struct {
 }
 
 type PieChartTheme struct {
-	Slices []Color
+	Slices Colors
 }
 
 type SparklineTheme struct {
@@ -87,9 +87,9 @@ type SparklineTheme struct {
 }
 
 type StackedBarChartTheme struct {
-	Bars   []Color
-	Nums   []Style
-	Labels []Style
+	Bars   Colors
+	Nums   Styles
+	Labels Styles
 }
 
 type TabTheme struct {
@@ -112,9 +112,9 @@ var Theme = RootTheme{
 	},
 
 	BarChart: BarChartTheme{
-		Bars:   StandardColors,
-		Nums:   StandardStyles,
-		Labels: StandardStyles,
+		Bars:   StandardColors.Clone(),
+		Nums:   StandardStyles.Clone(),
+		Labels: StandardStyles.Clone(),
 	},
 
 	Paragraph: ParagraphTheme{
@@ -122,7 +122,7 @@ var Theme = RootTheme{
 	},
 
 	PieChart: PieChartTheme{
-		Slices: StandardColors,
+		Slices: StandardColors.Clone(),
 	},
 
 	List: ListTheme{
@@ -136,9 +136,9 @@ var Theme = RootTheme{
 	},
 
 	StackedBarChart: StackedBarChartTheme{
-		Bars:   StandardColors,
-		Nums:   StandardStyles,
-		Labels: StandardStyles,
+		Bars:   StandardColors.Clone(),
+		Nums:   StandardStyles.Clone(),
+		Labels: StandardStyles.Clone(),
 	},
 
 	Gauge: GaugeTheme{
@@ -152,7 +152,7 @@ var Theme = RootTheme{
 	},
 
 	Plot: PlotTheme{
-		Lines: StandardColors,
+		Lines: StandardColors.Clone(),
 		Axes:  ColorWhite,
 	},
 

--- a/utils.go
+++ b/utils.go
@@ -41,11 +41,11 @@ func TrimString(s string, w int) string {
 	return s
 }
 
-func SelectColor(colors []Color, index int) Color {
+func SelectColor(colors Colors, index int) Color {
 	return colors[index%len(colors)]
 }
 
-func SelectStyle(styles []Style, index int) Style {
+func SelectStyle(styles Styles, index int) Style {
 	return styles[index%len(styles)]
 }
 

--- a/widgets/barchart.go
+++ b/widgets/barchart.go
@@ -15,9 +15,9 @@ import (
 
 type BarChart struct {
 	Block
-	BarColors    []Color
-	LabelStyles  []Style
-	NumStyles    []Style // only Fg and Modifier are used
+	BarColors    Colors
+	LabelStyles  Styles
+	NumStyles    Styles // only Fg and Modifier are used
 	NumFormatter func(float64) string
 	Data         []float64
 	Labels       []string
@@ -29,9 +29,9 @@ type BarChart struct {
 func NewBarChart() *BarChart {
 	return &BarChart{
 		Block:        *NewBlock(),
-		BarColors:    Theme.BarChart.Bars,
-		NumStyles:    Theme.BarChart.Nums,
-		LabelStyles:  Theme.BarChart.Labels,
+		BarColors:    Theme.BarChart.Bars.Clone(),
+		NumStyles:    Theme.BarChart.Nums.Clone(),
+		LabelStyles:  Theme.BarChart.Labels.Clone(),
 		NumFormatter: func(n float64) string { return fmt.Sprint(n) },
 		BarGap:       1,
 		BarWidth:     3,

--- a/widgets/piechart.go
+++ b/widgets/piechart.go
@@ -20,7 +20,7 @@ type PieChartLabel func(dataIndex int, currentValue float64) string
 type PieChart struct {
 	Block
 	Data           []float64     // list of data items
-	Colors         []Color       // colors to by cycled through
+	Colors         Colors        // colors to by cycled through
 	LabelFormatter PieChartLabel // callback function for labels
 	AngleOffset    float64       // which angle to start drawing at? (see piechartOffsetUp)
 }

--- a/widgets/plot.go
+++ b/widgets/plot.go
@@ -22,7 +22,7 @@ type Plot struct {
 	DataLabels []string
 	MaxVal     float64
 
-	LineColors []Color
+	LineColors Colors
 	AxesColor  Color // TODO
 	ShowAxes   bool
 
@@ -64,7 +64,7 @@ const (
 func NewPlot() *Plot {
 	return &Plot{
 		Block:           *NewBlock(),
-		LineColors:      Theme.Plot.Lines,
+		LineColors:      Theme.Plot.Lines.Clone(),
 		AxesColor:       Theme.Plot.Axes,
 		Marker:          MarkerBraille,
 		DotMarkerRune:   DOT,

--- a/widgets/stacked_barchart.go
+++ b/widgets/stacked_barchart.go
@@ -15,9 +15,9 @@ import (
 
 type StackedBarChart struct {
 	Block
-	BarColors    []Color
-	LabelStyles  []Style
-	NumStyles    []Style // only Fg and Modifier are used
+	BarColors    Colors
+	LabelStyles  Styles
+	NumStyles    Styles // only Fg and Modifier are used
 	NumFormatter func(float64) string
 	Data         [][]float64
 	Labels       []string
@@ -29,9 +29,9 @@ type StackedBarChart struct {
 func NewStackedBarChart() *StackedBarChart {
 	return &StackedBarChart{
 		Block:        *NewBlock(),
-		BarColors:    Theme.StackedBarChart.Bars,
-		LabelStyles:  Theme.StackedBarChart.Labels,
-		NumStyles:    Theme.StackedBarChart.Nums,
+		BarColors:    Theme.StackedBarChart.Bars.Clone(),
+		LabelStyles:  Theme.StackedBarChart.Labels.Clone(),
+		NumStyles:    Theme.StackedBarChart.Nums.Clone(),
 		NumFormatter: func(n float64) string { return fmt.Sprint(n) },
 		BarGap:       1,
 		BarWidth:     3,


### PR DESCRIPTION
I multiple plots are used as in the demo, the line colors can not be configured separately.
The reason is that the color slice from the template StandardColors are reuses and handed over by reference.

When the color is changed in one plot, then the slice in the other plot is also changed, hence, all lines with the same index have the same color.

This PR clones the color and style slice to get rid of this reference allowing to have different colors in different graphs.